### PR TITLE
Add normalization/models and harden EMH.vrt (input_kind + two-sided p-value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,29 +42,21 @@ Python 3.11 or higher is required.
 import numpy as np
 from variance_test import EMH
 
-# Generate or load log prices (NOT actual prices)
-# The VRT expects log prices where differences are log returns
-np.random.seed(42)
-log_prices = np.log(np.cumsum(np.random.randn(201)) * 0.01 + 100)
-
-# Initialize the Efficient Market Hypothesis tester
 emh = EMH()
 
-# Run the variance ratio test
-# q: aggregation horizon (e.g., q=2 for 2-period returns)
-# heteroskedastic: True for heteroskedastic null, False for homoskedastic null
-z_score, p_value = emh.vrt(
-    X=log_prices,
-    q=2,
-    heteroskedastic=False,  # Use homoskedastic test
-    centered=True,
-    unbiased=True,
-    annualize=False
-)
+# Modo log-prices (default histórico)
+log_prices = np.log(np.cumsum(np.random.randn(201)) * 0.01 + 100)
+z_score, p_value = emh.vrt(X=log_prices, q=4, input_kind="log_prices")
 
-print(f"z-statistic: {z_score:.4f}")
-print(f"p-value: {p_value:.4f}")
+# Modo returns
+returns = np.diff(log_prices)
+z_score, p_value = emh.vrt(X=returns, q=4, input_kind="returns")
 ```
+
+`EMH.vrt` interpreta `X` como **log-prices** por default para mantener compatibilidad histórica.
+Desde este sprint también acepta **returns** con `input_kind="returns"`; en ese caso,
+reconstruye internamente una serie sintética de log-prices con origen `0.0` y aplica
+el mismo VRT.
 
 ### Running Simulations
 
@@ -146,13 +138,13 @@ The `price_paths.py` module generates price trajectories for various stochastic 
 - **Cox-Ingersoll-Ross (CIR)**: Square-root diffusion process
 - **Ornstein-Uhlenbeck Process**: Mean-reverting process
 
-**Important**: All price path generators return **actual prices**, not log prices. The simulation framework automatically converts these to log prices before applying the VRT.
+**Important**: All price path generators return **actual prices**, not log-prices. The simulation framework automatically converts actual prices to log-prices before applying the VRT.
 
 ### Key Features
 
 - ✅ Correct implementation of Lo & MacKinlay (1988) formulas
 - ✅ Both homoskedastic and heteroskedastic tests
-- ✅ Proper handling of log prices vs. actual prices
+- ✅ Proper handling of log-prices vs. actual prices
 - ✅ Edge case handling for small samples
 - ✅ Multiple stochastic process simulations
 - ✅ Comprehensive testing framework

--- a/src/variance_test/__init__.py
+++ b/src/variance_test/__init__.py
@@ -1,6 +1,8 @@
 """Public package interface for variance ratio testing."""
 
 from .core import EMH
+from .data import NormalizedSeries, normalize_series
+from .models import BatteryConfig, BatteryOutcome, TestOutcome
 from .price_paths import PricePaths
 from .simulation import (
     SimulationConfig,
@@ -20,4 +22,9 @@ __all__ = [
     "simulate_price_processes",
     "compute_vrt_statistics",
     "run_simulation",
+    "NormalizedSeries",
+    "normalize_series",
+    "BatteryConfig",
+    "TestOutcome",
+    "BatteryOutcome",
 ]

--- a/src/variance_test/core.py
+++ b/src/variance_test/core.py
@@ -3,6 +3,8 @@
 import numpy as np
 import scipy.stats as st
 
+from .data import normalize_series
+
 
 class EMH(object):
     """Empirical tests for the Efficient Market Hypothesis."""
@@ -11,19 +13,11 @@ class EMH(object):
     # Homoskedastic Null Hypothesis
     # ------------------------------------------------------------------
 
-    def __prepare_prices(self, X: np.ndarray) -> np.ndarray:
-        """Validate and standardize a price series into a 1-D NumPy array."""
-
-        prices = np.asarray(X, dtype=float).reshape(-1)
-        if prices.size < 2:
-            raise ValueError("At least two observations are required to estimate drift.")
-
-        return prices
 
     def __mu(self, X: np.ndarray, annualize: bool = True) -> float:
         """Estimate the drift component of a log price process."""
 
-        prices = self.__prepare_prices(X)
+        prices = np.asarray(X, dtype=float)
         mu_est = (prices[-1] - prices[0]) / prices.shape[0]
         return float(mu_est * 252) if annualize else float(mu_est)
 
@@ -39,7 +33,7 @@ class EMH(object):
         if q <= 0:
             raise ValueError("Aggregation horizon q must be a positive integer.")
 
-        series = self.__prepare_prices(prices)
+        series = np.asarray(prices, dtype=float)
         n_obs = series.shape[0]
         if n_obs <= q:
             raise ValueError("Not enough observations for the requested aggregation horizon.")
@@ -135,7 +129,7 @@ class EMH(object):
         if q <= 0:
             raise ValueError("Aggregation horizon q must be a positive integer.")
 
-        prices = self.__prepare_prices(X)
+        prices = np.asarray(X, dtype=float)
         n = np.floor(prices.shape[0] / q)
         if n <= 0:
             raise ValueError("Not enough observations for the requested aggregation horizon.")
@@ -164,7 +158,7 @@ class EMH(object):
         if j <= 0 or j >= q:
             raise ValueError("Lag j must satisfy 0 < j < q.")
 
-        prices = self.__prepare_prices(X)
+        prices = np.asarray(X, dtype=float)
         n = int(np.floor(prices.shape[0] / q))
         upper_bound = n * q
         if upper_bound <= j + 1:
@@ -201,7 +195,7 @@ class EMH(object):
         if q < 3:
             raise ValueError("q must be at least 3 for the heteroskedastic variance estimator.")
 
-        prices = self.__prepare_prices(X)
+        prices = np.asarray(X, dtype=float)
         n = int(np.floor(prices.shape[0] / q))
         upper_bound = n * q
         if upper_bound <= q:
@@ -230,7 +224,7 @@ class EMH(object):
         if not centered:
             raise ValueError("Non-centered heteroskedastic statistic is not implemented.")
 
-        prices = self.__prepare_prices(X)
+        prices = np.asarray(X, dtype=float)
         n = np.floor(prices.shape[0] / q)
         if n <= 0:
             raise ValueError("Not enough observations for the requested aggregation horizon.")
@@ -253,17 +247,65 @@ class EMH(object):
         centered: bool = True,
         unbiased: bool = True,
         annualize: bool = True,
+        *,
+        input_kind: str = "log_prices",
+        alternative: str = "two-sided",
     ):
-        """Compute the Variance Ratio test statistic and its p-value."""
+        """Compute the Variance Ratio test statistic and p-value.
+
+        Historical behavior is preserved: by default, ``X`` is interpreted as
+        ``input_kind="log_prices"``. You may also pass raw returns via
+        ``input_kind="returns"``; the method reconstructs synthetic log-prices
+        with origin ``0.0`` internally and reuses the same VRT math pipeline.
+
+        Args:
+            X: One-dimensional series of log-prices or returns.
+            q: Aggregation horizon.
+            heteroskedastic: Whether to use heteroskedastic asymptotic variance.
+            centered: Whether to use centered statistic.
+            unbiased: Whether to use unbiased variance/autocovariance estimators.
+            annualize: Scales intermediate volatility estimators only; it does
+                not change the test-statistic logic itself.
+            input_kind: ``"log_prices"`` (default) or ``"returns"``.
+            alternative: Tail alternative for p-value calculation:
+                ``"two-sided"`` uses ``2 * (1 - Phi(abs(z)))``;
+                ``"greater"`` uses ``1 - Phi(z)``;
+                ``"less"`` uses ``Phi(z)``.
+
+        Returns:
+            A tuple ``(z_score, p_value)``.
+        """
+
+        if input_kind not in {"log_prices", "returns"}:
+            raise ValueError("input_kind must be 'log_prices' or 'returns'.")
+        if alternative not in {"two-sided", "greater", "less"}:
+            raise ValueError("alternative must be 'two-sided', 'greater', or 'less'.")
+
+        normalized = normalize_series(X, input_kind=input_kind)
+        log_prices = normalized.log_prices
 
         if heteroskedastic:
             z_score = self.__h2(
-                X=X, q=q, centered=centered, unbiased=unbiased, annualize=annualize
+                X=log_prices,
+                q=q,
+                centered=centered,
+                unbiased=unbiased,
+                annualize=annualize,
             )
         else:
             z_score = self.__h1(
-                X=X, q=q, centered=centered, unbiased=unbiased, annualize=annualize
+                X=log_prices,
+                q=q,
+                centered=centered,
+                unbiased=unbiased,
+                annualize=annualize,
             )
 
-        p_value = 1 - st.norm.cdf(z_score)
+        if alternative == "two-sided":
+            p_value = 2 * (1 - st.norm.cdf(abs(z_score)))
+        elif alternative == "greater":
+            p_value = 1 - st.norm.cdf(z_score)
+        else:
+            p_value = st.norm.cdf(z_score)
+
         return z_score, p_value

--- a/src/variance_test/data.py
+++ b/src/variance_test/data.py
@@ -1,0 +1,80 @@
+"""Data normalization utilities for variance-test inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class NormalizedSeries:
+    """Canonical normalized representation for input series."""
+
+    input_kind: str
+    raw: np.ndarray
+    returns: np.ndarray
+    log_prices: np.ndarray
+    squared_returns: np.ndarray
+    signs: np.ndarray
+    n_raw: int
+    n_returns: int
+
+
+def normalize_series(series, input_kind: str = "log_prices") -> NormalizedSeries:
+    """Validate and normalize an input series as log-prices or returns.
+
+    Args:
+        series: One-dimensional array-like numeric sequence.
+        input_kind: Semantic type of the input series. Must be
+            ``"log_prices"`` or ``"returns"``.
+
+    Returns:
+        A :class:`NormalizedSeries` instance with aligned derived arrays.
+
+    Raises:
+        ValueError: If ``input_kind`` is invalid, the data is not one-dimensional,
+            contains non-finite values, or is too short for the selected kind.
+    """
+
+    if input_kind not in {"log_prices", "returns"}:
+        raise ValueError("input_kind must be 'log_prices' or 'returns'.")
+
+    raw = np.asarray(series, dtype=float)
+    if raw.ndim != 1:
+        raise ValueError("Input series must be one-dimensional.")
+    if raw.size == 0:
+        raise ValueError("Input series cannot be empty.")
+    if not np.isfinite(raw).all():
+        raise ValueError("Input series must contain only finite values.")
+
+    if input_kind == "log_prices":
+        if raw.size < 2:
+            raise ValueError("log_prices input requires at least 2 observations.")
+
+        log_prices = raw
+        returns = np.diff(log_prices)
+        n_raw = int(log_prices.size)
+        n_returns = int(returns.size)
+    else:
+        if raw.size < 1:
+            raise ValueError("returns input requires at least 1 observation.")
+
+        returns = raw
+        log_prices = np.concatenate(([0.0], np.cumsum(returns)))
+        n_raw = int(returns.size)
+        n_returns = int(returns.size)
+
+    squared_returns = returns ** 2
+    signs = np.sign(returns)
+
+    return NormalizedSeries(
+        input_kind=input_kind,
+        raw=raw,
+        returns=returns,
+        log_prices=log_prices,
+        squared_returns=squared_returns,
+        signs=signs,
+        n_raw=n_raw,
+        n_returns=n_returns,
+    )

--- a/src/variance_test/models.py
+++ b/src/variance_test/models.py
@@ -1,0 +1,101 @@
+"""Dataclass models for battery configuration and outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BatteryConfig:
+    """Configuration contract for the weak-form battery orchestration layer."""
+
+    input_kind: str = "log_prices"
+    alpha: float = 0.05
+    q_list: tuple[int, ...] = (2, 4, 8, 16)
+    ljung_box_lags: tuple[int, ...] = (5, 10, 20)
+    runs_test: bool = True
+    arch_lm_lags: int = 5
+    rolling_window: int | None = None
+    rolling_step: int = 1
+    seed: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.input_kind not in {"log_prices", "returns"}:
+            raise ValueError("input_kind must be 'log_prices' or 'returns'.")
+        if not (0 < self.alpha < 1):
+            raise ValueError("alpha must satisfy 0 < alpha < 1.")
+        if not self.q_list:
+            raise ValueError("q_list cannot be empty.")
+        if any((not isinstance(q, int)) or q <= 0 for q in self.q_list):
+            raise ValueError("All q_list values must be positive integers.")
+        if any(curr <= prev for prev, curr in zip(self.q_list, self.q_list[1:])):
+            raise ValueError("q_list must be strictly increasing.")
+
+        if not self.ljung_box_lags:
+            raise ValueError("ljung_box_lags cannot be empty.")
+        if any((not isinstance(lag, int)) or lag <= 0 for lag in self.ljung_box_lags):
+            raise ValueError("All ljung_box_lags values must be positive integers.")
+
+        if self.arch_lm_lags < 1:
+            raise ValueError("arch_lm_lags must be at least 1.")
+        if self.rolling_window is not None and self.rolling_window < 2:
+            raise ValueError("rolling_window must be None or at least 2.")
+        if self.rolling_step < 1:
+            raise ValueError("rolling_step must be at least 1.")
+
+
+@dataclass
+class TestOutcome:
+    """Result contract for a single statistical test."""
+
+    name: str
+    null_hypothesis: str
+    statistic: float | None
+    p_value: float | None
+    alpha: float
+    reject_null: bool | None
+    metadata: dict[str, object]
+    warnings: list[str]
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name cannot be empty.")
+        if not self.null_hypothesis:
+            raise ValueError("null_hypothesis cannot be empty.")
+        if not (0 < self.alpha < 1):
+            raise ValueError("alpha must satisfy 0 < alpha < 1.")
+
+        if self.p_value is not None and not (0 <= self.p_value <= 1):
+            raise ValueError("p_value must be in [0, 1] when provided.")
+
+        if self.reject_null is not None and self.p_value is not None:
+            expected_reject = self.p_value < self.alpha
+            if self.reject_null != expected_reject:
+                raise ValueError("reject_null is inconsistent with p_value and alpha.")
+
+
+@dataclass
+class BatteryOutcome:
+    """Result contract for a complete weak-form battery execution."""
+
+    input_kind: str
+    n_obs: int
+    returns_n_obs: int
+    tests: dict[str, TestOutcome]
+    multiple_testing: dict[str, object]
+    rolling: dict[str, object] | None
+    warnings: list[str]
+
+    def __post_init__(self) -> None:
+        if self.input_kind not in {"log_prices", "returns"}:
+            raise ValueError("input_kind must be 'log_prices' or 'returns'.")
+        if self.n_obs < 1:
+            raise ValueError("n_obs must be at least 1.")
+        if self.returns_n_obs < 0:
+            raise ValueError("returns_n_obs must be non-negative.")
+
+        for key, value in self.tests.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError("tests keys must be non-empty strings.")
+            if not isinstance(value, TestOutcome):
+                raise ValueError("tests values must be TestOutcome instances.")

--- a/tests/test_data_normalization.py
+++ b/tests/test_data_normalization.py
@@ -1,0 +1,67 @@
+"""Tests for series normalization utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from variance_test import normalize_series
+
+
+def test_normalize_log_prices_outputs_expected_derived_arrays() -> None:
+    """log_prices input must produce consistent derived return arrays."""
+    log_prices = np.array([0.0, 0.1, 0.15, 0.12], dtype=float)
+
+    ns = normalize_series(log_prices, input_kind="log_prices")
+
+    expected_returns = np.diff(log_prices)
+    np.testing.assert_allclose(ns.returns, expected_returns)
+    np.testing.assert_allclose(ns.squared_returns, expected_returns**2)
+    np.testing.assert_allclose(ns.signs, np.sign(expected_returns))
+    assert ns.n_raw == len(log_prices)
+    assert ns.n_returns == len(log_prices) - 1
+
+
+def test_normalize_returns_reconstructs_synthetic_log_prices() -> None:
+    """returns input must reconstruct log-prices with origin 0.0."""
+    returns = np.array([0.01, -0.02, 0.03], dtype=float)
+
+    ns = normalize_series(returns, input_kind="returns")
+
+    np.testing.assert_allclose(ns.returns, returns)
+    assert ns.log_prices[0] == 0.0
+    np.testing.assert_allclose(ns.log_prices[1:], np.cumsum(returns))
+    assert ns.n_raw == len(returns)
+    assert ns.n_returns == len(returns)
+
+
+def test_normalize_series_rejects_invalid_input_kind() -> None:
+    """An invalid input_kind must raise ValueError."""
+    with pytest.raises(ValueError):
+        normalize_series([0.0, 0.1], input_kind="invalid")
+
+
+def test_normalize_series_rejects_empty_array() -> None:
+    """An empty series must raise ValueError."""
+    with pytest.raises(ValueError):
+        normalize_series([], input_kind="returns")
+
+
+def test_normalize_series_rejects_nan_and_inf() -> None:
+    """Series containing NaN or inf must raise ValueError."""
+    with pytest.raises(ValueError):
+        normalize_series([0.0, np.nan], input_kind="log_prices")
+    with pytest.raises(ValueError):
+        normalize_series([0.0, np.inf], input_kind="log_prices")
+
+
+def test_normalize_series_rejects_two_dimensional_input() -> None:
+    """A two-dimensional input must raise ValueError."""
+    with pytest.raises(ValueError):
+        normalize_series(np.array([[0.0, 0.1], [0.2, 0.3]]), input_kind="log_prices")
+
+
+def test_normalize_series_rejects_too_short_log_prices() -> None:
+    """log_prices input with one observation must raise ValueError."""
+    with pytest.raises(ValueError):
+        normalize_series([0.0], input_kind="log_prices")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,103 @@
+"""Tests for Sprint 2 data contract models."""
+
+from __future__ import annotations
+
+import pytest
+
+from variance_test import BatteryConfig, BatteryOutcome, TestOutcome
+
+
+def test_battery_config_defaults_construct() -> None:
+    """BatteryConfig must construct with default values."""
+    config = BatteryConfig()
+    assert config.input_kind == "log_prices"
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.0, -0.1])
+def test_battery_config_rejects_invalid_alpha(alpha: float) -> None:
+    """alpha must satisfy strict open interval constraints."""
+    with pytest.raises(ValueError):
+        BatteryConfig(alpha=alpha)
+
+
+def test_battery_config_rejects_empty_q_list() -> None:
+    """q_list cannot be empty."""
+    with pytest.raises(ValueError):
+        BatteryConfig(q_list=())
+
+
+@pytest.mark.parametrize("q_list", [(4, 2, 8), (2, 2, 8)])
+def test_battery_config_requires_strictly_increasing_q_list(q_list: tuple[int, ...]) -> None:
+    """q_list must be strictly increasing."""
+    with pytest.raises(ValueError):
+        BatteryConfig(q_list=q_list)
+
+
+def test_battery_config_rejects_empty_ljung_box_lags() -> None:
+    """ljung_box_lags cannot be empty."""
+    with pytest.raises(ValueError):
+        BatteryConfig(ljung_box_lags=())
+
+
+def test_battery_config_rejects_arch_lm_lags_less_than_one() -> None:
+    """arch_lm_lags must be at least 1."""
+    with pytest.raises(ValueError):
+        BatteryConfig(arch_lm_lags=0)
+
+
+def test_test_outcome_valid_consistent_rejection_constructs() -> None:
+    """A consistent reject_null value must be accepted."""
+    outcome = TestOutcome(
+        name="vrt",
+        null_hypothesis="random walk",
+        statistic=2.0,
+        p_value=0.01,
+        alpha=0.05,
+        reject_null=True,
+        metadata={},
+        warnings=[],
+    )
+    assert outcome.reject_null is True
+
+
+def test_test_outcome_reject_null_consistency_is_enforced() -> None:
+    """An inconsistent reject_null value must raise ValueError."""
+    with pytest.raises(ValueError):
+        TestOutcome(
+            name="vrt",
+            null_hypothesis="random walk",
+            statistic=2.0,
+            p_value=0.01,
+            alpha=0.05,
+            reject_null=False,
+            metadata={},
+            warnings=[],
+        )
+
+
+def test_battery_outcome_accepts_empty_tests() -> None:
+    """BatteryOutcome may contain an empty tests mapping in this sprint."""
+    outcome = BatteryOutcome(
+        input_kind="log_prices",
+        n_obs=10,
+        returns_n_obs=9,
+        tests={},
+        multiple_testing={},
+        rolling=None,
+        warnings=[],
+    )
+    assert outcome.tests == {}
+
+
+def test_battery_outcome_rejects_non_test_outcome_values() -> None:
+    """tests values must be instances of TestOutcome."""
+    with pytest.raises(ValueError):
+        BatteryOutcome(
+            input_kind="log_prices",
+            n_obs=10,
+            returns_n_obs=9,
+            tests={"vrt": "invalid"},
+            multiple_testing={},
+            rolling=None,
+            warnings=[],
+        )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from variance_test import (
+    BatteryConfig,
+    BatteryOutcome,
     EMH,
+    NormalizedSeries,
     PricePaths,
     SimulationConfig,
     SimulationResults,
+    TestOutcome,
     compute_vrt_statistics,
+    normalize_series,
     run_simulation,
     simulate_price_processes,
 )
@@ -23,6 +28,11 @@ EXPECTED_PUBLIC_API = {
     "simulate_price_processes",
     "compute_vrt_statistics",
     "run_simulation",
+    "NormalizedSeries",
+    "normalize_series",
+    "BatteryConfig",
+    "TestOutcome",
+    "BatteryOutcome",
 }
 
 
@@ -44,6 +54,15 @@ def test_simulation_entities_importable_from_root() -> None:
     assert simulate_price_processes is not None
     assert compute_vrt_statistics is not None
     assert run_simulation is not None
+
+
+def test_new_data_contract_api_importable_from_root() -> None:
+    """Sprint 2 data/model contracts must be importable from package root."""
+    assert NormalizedSeries is not None
+    assert normalize_series is not None
+    assert BatteryConfig is not None
+    assert TestOutcome is not None
+    assert BatteryOutcome is not None
 
 
 def test_all_contains_exact_public_api() -> None:

--- a/tests/test_vrt_hardening.py
+++ b/tests/test_vrt_hardening.py
@@ -1,0 +1,85 @@
+"""Tests for VRT input hardening and p-value alternatives."""
+
+from __future__ import annotations
+
+import numpy as np
+import scipy.stats as st
+import pytest
+
+from variance_test import EMH
+
+
+def _sample_log_prices() -> np.ndarray:
+    rng = np.random.default_rng(7)
+    returns = rng.normal(0.0, 0.01, size=200)
+    return np.concatenate([[0.0], np.cumsum(returns)])
+
+
+def test_vrt_legacy_signature_returns_two_numeric_values() -> None:
+    """Legacy call must still return (z_score, p_value)."""
+    log_prices = _sample_log_prices()
+
+    result = EMH().vrt(X=log_prices, q=3)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert np.isfinite(result[0])
+    assert np.isfinite(result[1])
+
+
+def test_vrt_default_two_sided_pvalue_matches_formula() -> None:
+    """Default p-value must be two-sided and based on abs(z)."""
+    log_prices = _sample_log_prices()
+    z_score, p_value = EMH().vrt(X=log_prices, q=3)
+
+    expected = 2 * (1 - st.norm.cdf(abs(z_score)))
+    np.testing.assert_allclose(p_value, expected, atol=1e-12)
+
+
+def test_vrt_one_sided_alternatives_match_tail_probabilities() -> None:
+    """greater and less alternatives must match one-sided normal tails."""
+    log_prices = _sample_log_prices()
+    z_score, _ = EMH().vrt(X=log_prices, q=3, alternative="two-sided")
+    _, p_greater = EMH().vrt(X=log_prices, q=3, alternative="greater")
+    _, p_less = EMH().vrt(X=log_prices, q=3, alternative="less")
+
+    np.testing.assert_allclose(p_greater, 1 - st.norm.cdf(z_score), atol=1e-12)
+    np.testing.assert_allclose(p_less, st.norm.cdf(z_score), atol=1e-12)
+
+
+def test_vrt_rejects_invalid_alternative() -> None:
+    """Invalid alternative must raise ValueError."""
+    log_prices = _sample_log_prices()
+    with pytest.raises(ValueError):
+        EMH().vrt(X=log_prices, q=3, alternative="invalid")
+
+
+def test_vrt_accepts_returns_input_and_returns_finite_values() -> None:
+    """returns input_kind must be accepted with finite output values."""
+    rng = np.random.default_rng(11)
+    returns = rng.normal(0.0, 0.01, size=120)
+
+    z_score, p_value = EMH().vrt(X=returns, q=2, input_kind="returns")
+
+    assert np.isfinite(z_score)
+    assert np.isfinite(p_value)
+
+
+def test_vrt_returns_mode_matches_synthetic_log_prices_mode() -> None:
+    """returns mode must match equivalent synthetic log-prices mode."""
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0, 0.01, size=100)
+    log_prices_synthetic = np.concatenate([[0.0], np.cumsum(returns)])
+
+    z1, p1 = EMH().vrt(X=returns, q=4, input_kind="returns", annualize=False)
+    z2, p2 = EMH().vrt(X=log_prices_synthetic, q=4, input_kind="log_prices", annualize=False)
+
+    assert abs(z1 - z2) < 1e-10
+    assert abs(p1 - p2) < 1e-10
+
+
+def test_vrt_rejects_invalid_input_kind() -> None:
+    """Invalid input_kind must raise ValueError."""
+    log_prices = _sample_log_prices()
+    with pytest.raises(ValueError):
+        EMH().vrt(X=log_prices, q=3, input_kind="invalid")


### PR DESCRIPTION
### Motivation
- Ensure a single, strict normalization pathway for all user inputs and define stable dataclass contracts for future battery orchestration.
- Harden the classic Variance Ratio Test (VRT) interface to close input semantics (log-prices vs returns) while remaining backward-compatible.
- Remove ambiguity in README about what the VRT expects and how returns are handled so future work has an unambiguous baseline.

### Description
- Added `src/variance_test/data.py` implementing `NormalizedSeries` (dataclass) and `normalize_series(...)` which validates 1-D array-like inputs, rejects empty/NaN/inf/NDIM!=1, enforces minimum lengths, and reconstructs synthetic log-prices from `returns` with origin `0.0`.
- Added `src/variance_test/models.py` implementing dataclasses `BatteryConfig`, `TestOutcome`, and `BatteryOutcome` with the exact fields and `__post_init__` validations required by the sprint (input_kind checks, alpha range, q_list monotonicity, lag checks, consistency between `p_value` and `reject_null`, etc.).
- Hardened `EMH.vrt(...)` in `src/variance_test/core.py` by delegating input validation to `normalize_series(...)`, adding two keyword-only parameters `input_kind: str = "log_prices"` and `alternative: str = "two-sided"` (backwards-compatible), validating both, reconstructing synthetic `log_prices` for `input_kind="returns"`, and computing p-values as:
  - two-sided: `2 * (1 - Phi(abs(z_score)))`
  - greater: `1 - Phi(z_score)`
  - less: `Phi(z_score)`
- Updated package root export (`src/variance_test/__init__.py`) to include `NormalizedSeries`, `normalize_series`, `BatteryConfig`, `TestOutcome`, and `BatteryOutcome` in `__all__` without wildcard imports.
- Updated `README.md` to remove ambiguity between "prices" and "log-prices", document the default interpretation (`log_prices`), and include minimal examples showing both `input_kind="log_prices"` and `input_kind="returns"` usage.
- Added tests required by the sprint: `tests/test_data_normalization.py`, `tests/test_models.py`, `tests/test_vrt_hardening.py`, and updated `tests/test_public_api.py` to include the new public symbols.

### Testing
- Ran `pytest -q`; collection failed during import because runtime dependency `numpy` was not available in the execution environment (ModuleNotFoundError for `numpy`), so tests could not be executed to completion.
- Attempted `python -m pip install -e .`; installation failed because build dependencies could not be downloaded in this environment due to network/proxy restrictions (error fetching `setuptools>=68`).
- Local static checks performed in the rollout: source files created and unit test files added and syntactically validated by the edit/commit operations in the environment; however automated test execution was blocked by missing runtime/build dependencies as described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6de87c0b08323ad8fd27c25ae90e3)