### PR TITLE
Implement Sprint 3: weak-form battery v1 (`run_weak_form_battery`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,36 @@ Desde este sprint también acepta **returns** con `input_kind="returns"`; en ese
 reconstruye internamente una serie sintética de log-prices con origen `0.0` y aplica
 el mismo VRT.
 
+
+### Weak-form Battery v1
+
+The package now includes an executable weak-form efficiency battery via `run_weak_form_battery(...)`.
+
+Battery v1 includes:
+- variance ratio multi-q
+- Ljung-Box returns
+- Ljung-Box squared returns
+- runs test on signs
+- ARCH LM
+- Holm summary for the VR family
+
+```python
+import numpy as np
+from variance_test import BatteryConfig, run_weak_form_battery
+
+rng = np.random.default_rng(42)
+returns = rng.normal(0.0, 0.01, size=2000)
+
+config = BatteryConfig(input_kind="returns", q_list=(2, 4, 8), ljung_box_lags=(5, 10, 20))
+outcome = run_weak_form_battery(returns, config=config)
+print(outcome.multiple_testing["battery_summary"])
+```
+
+> Warning: this battery provides evidence against compatibility with weak-form efficiency **under this battery**.
+> It is **not** definitive proof of market inefficiency.
+>
+> Note: `rolling = None` in this version.
+
 ### Running Simulations
 
 The package includes a comprehensive simulation framework to test the VRT on different stochastic processes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "numpy",
   "scipy",
   "matplotlib",
+  "statsmodels",
 ]
 
 [project.urls]

--- a/src/variance_test/__init__.py
+++ b/src/variance_test/__init__.py
@@ -1,5 +1,6 @@
 """Public package interface for variance ratio testing."""
 
+from .battery import run_weak_form_battery
 from .core import EMH
 from .data import NormalizedSeries, normalize_series
 from .models import BatteryConfig, BatteryOutcome, TestOutcome
@@ -27,4 +28,5 @@ __all__ = [
     "BatteryConfig",
     "TestOutcome",
     "BatteryOutcome",
+    "run_weak_form_battery",
 ]

--- a/src/variance_test/battery.py
+++ b/src/variance_test/battery.py
@@ -1,0 +1,358 @@
+"""Weak-form efficiency battery orchestration utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import stats
+from statsmodels.stats import diagnostic
+
+from .core import EMH
+from .data import normalize_series
+from .models import BatteryConfig, BatteryOutcome, TestOutcome
+
+
+def _validate_battery_compatibility(normalized, config: BatteryConfig) -> None:
+    """Validate that configured horizons/lags are compatible with the input length."""
+    n_log_prices = int(normalized.log_prices.size)
+    for q in config.q_list:
+        if q >= n_log_prices:
+            raise ValueError("Each q must satisfy q < normalized.log_prices.size.")
+
+    max_lag = max(config.ljung_box_lags)
+    if max_lag >= normalized.n_returns:
+        raise ValueError("max(config.ljung_box_lags) must satisfy < normalized.n_returns.")
+
+    if config.arch_lm_lags >= normalized.n_returns:
+        raise ValueError("config.arch_lm_lags must satisfy < normalized.n_returns.")
+
+
+def _run_variance_ratio_family(normalized, config: BatteryConfig) -> dict[str, TestOutcome]:
+    """Run multi-horizon variance ratio tests using EMH.vrt."""
+    emh = EMH()
+    outcomes: dict[str, TestOutcome] = {}
+
+    for q in config.q_list:
+        z_score, p_value = emh.vrt(
+            X=normalized.log_prices,
+            q=q,
+            heteroskedastic=True,
+            centered=True,
+            unbiased=True,
+            annualize=False,
+            input_kind="log_prices",
+            alternative="two-sided",
+        )
+        name = f"variance_ratio_q{q}"
+        outcomes[name] = TestOutcome(
+            name=name,
+            null_hypothesis="Variance ratio equals 1 under the random walk null.",
+            statistic=float(z_score),
+            p_value=float(p_value),
+            alpha=config.alpha,
+            reject_null=bool(p_value < config.alpha),
+            metadata={
+                "q": q,
+                "heteroskedastic": True,
+                "centered": True,
+                "unbiased": True,
+                "annualize": False,
+                "input_kind_used": "log_prices",
+                "alternative": "two-sided",
+            },
+            warnings=[],
+        )
+
+    return outcomes
+
+
+def _apply_holm_bonferroni(vr_outcomes: list[TestOutcome], alpha: float) -> dict[str, object]:
+    """Apply Holm-Bonferroni correction to the variance-ratio family."""
+    family = [outcome.name for outcome in vr_outcomes]
+    raw_p_values = {outcome.name: float(outcome.p_value) for outcome in vr_outcomes}
+
+    sorted_outcomes = sorted(vr_outcomes, key=lambda item: (float(item.p_value), item.name))
+    m = len(sorted_outcomes)
+
+    thresholds: dict[str, float] = {}
+    rejections: dict[str, bool] = {name: False for name in family}
+
+    stop = False
+    for i, outcome in enumerate(sorted_outcomes):
+        threshold = alpha / (m - i)
+        thresholds[outcome.name] = float(threshold)
+
+        if stop:
+            rejections[outcome.name] = False
+            continue
+
+        if float(outcome.p_value) <= threshold:
+            rejections[outcome.name] = True
+        else:
+            rejections[outcome.name] = False
+            stop = True
+
+    return {
+        "method": "holm-bonferroni",
+        "family": family,
+        "raw_p_values": raw_p_values,
+        "sorted_tests": [outcome.name for outcome in sorted_outcomes],
+        "thresholds": thresholds,
+        "rejections": rejections,
+        "any_reject": any(rejections.values()),
+    }
+
+
+def _run_ljung_box(series: np.ndarray, lags: tuple[int, ...], alpha: float, name: str, null_hypothesis: str) -> TestOutcome:
+    """Run Ljung-Box test and select the lag with minimum p-value."""
+    lb_stat, lb_pvalue = diagnostic.acorr_ljungbox(series, lags=list(lags), return_df=False)
+
+    per_lag: dict[int, dict[str, float | bool]] = {}
+    selected_lag = int(lags[0])
+    selected_p = float(lb_pvalue[0])
+
+    for lag, stat_value, p_value in zip(lags, lb_stat, lb_pvalue):
+        lag_int = int(lag)
+        stat_float = float(stat_value)
+        p_float = float(p_value)
+        per_lag[lag_int] = {
+            "statistic": stat_float,
+            "p_value": p_float,
+            "reject_null": bool(p_float < alpha),
+        }
+
+        if p_float < selected_p or (np.isclose(p_float, selected_p) and lag_int < selected_lag):
+            selected_lag = lag_int
+            selected_p = p_float
+
+    selected_stat = float(per_lag[selected_lag]["statistic"])
+
+    return TestOutcome(
+        name=name,
+        null_hypothesis=null_hypothesis,
+        statistic=selected_stat,
+        p_value=selected_p,
+        alpha=alpha,
+        reject_null=bool(selected_p < alpha),
+        metadata={
+            "tested_lags": list(lags),
+            "selected_lag": selected_lag,
+            "per_lag": per_lag,
+        },
+        warnings=[],
+    )
+
+
+def _run_runs_test(normalized, alpha: float) -> TestOutcome:
+    """Run bilateral Wald-Wolfowitz runs test over non-zero return signs."""
+    non_zero_returns = normalized.returns[normalized.returns != 0.0]
+    signs = np.sign(non_zero_returns)
+
+    n_effective = int(signs.size)
+    n_positive = int(np.sum(signs > 0))
+    n_negative = int(np.sum(signs < 0))
+
+    if n_effective < 2:
+        return TestOutcome(
+            name="runs_test_signs",
+            null_hypothesis="Signs of non-zero returns are random.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "n_effective": n_effective,
+                "n_positive": n_positive,
+                "n_negative": n_negative,
+                "reason": "effective length is less than 2",
+            },
+            warnings=["Runs test not computable: effective length is less than 2."],
+        )
+
+    if n_positive == 0 or n_negative == 0:
+        return TestOutcome(
+            name="runs_test_signs",
+            null_hypothesis="Signs of non-zero returns are random.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "n_effective": n_effective,
+                "n_positive": n_positive,
+                "n_negative": n_negative,
+                "reason": "both positive and negative signs are required",
+            },
+            warnings=["Runs test not computable: both sign classes are required."],
+        )
+
+    runs = int(1 + np.sum(signs[1:] != signs[:-1]))
+    expected_runs = 1 + (2 * n_positive * n_negative) / (n_positive + n_negative)
+    variance_runs = (
+        2
+        * n_positive
+        * n_negative
+        * (2 * n_positive * n_negative - n_positive - n_negative)
+        / (((n_positive + n_negative) ** 2) * (n_positive + n_negative - 1))
+    )
+
+    if variance_runs <= 0:
+        return TestOutcome(
+            name="runs_test_signs",
+            null_hypothesis="Signs of non-zero returns are random.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "n_effective": n_effective,
+                "n_positive": n_positive,
+                "n_negative": n_negative,
+                "reason": "theoretical runs variance is non-positive",
+            },
+            warnings=["Runs test not computable: theoretical variance is non-positive."],
+        )
+
+    z_score = (runs - expected_runs) / np.sqrt(variance_runs)
+    p_value = 2 * (1 - stats.norm.cdf(abs(z_score)))
+
+    return TestOutcome(
+        name="runs_test_signs",
+        null_hypothesis="Signs of non-zero returns are random.",
+        statistic=float(z_score),
+        p_value=float(p_value),
+        alpha=alpha,
+        reject_null=bool(p_value < alpha),
+        metadata={
+            "n_effective": n_effective,
+            "n_positive": n_positive,
+            "n_negative": n_negative,
+            "runs": runs,
+            "expected_runs": float(expected_runs),
+            "variance_runs": float(variance_runs),
+        },
+        warnings=[],
+    )
+
+
+def _run_arch_lm(returns: np.ndarray, nlags: int, alpha: float) -> TestOutcome:
+    """Run ARCH LM test and return a standardized TestOutcome."""
+    lm_stat, lm_p_value, f_stat, f_p_value = diagnostic.het_arch(returns, nlags=nlags)
+
+    return TestOutcome(
+        name="arch_lm",
+        null_hypothesis="No ARCH effects are present up to the tested lag order.",
+        statistic=float(lm_stat),
+        p_value=float(lm_p_value),
+        alpha=alpha,
+        reject_null=bool(lm_p_value < alpha),
+        metadata={
+            "nlags": nlags,
+            "lm_stat": float(lm_stat),
+            "lm_p_value": float(lm_p_value),
+            "f_stat": float(f_stat),
+            "f_p_value": float(f_p_value),
+        },
+        warnings=[],
+    )
+
+
+def _build_battery_summary(tests: dict[str, TestOutcome]) -> dict[str, object]:
+    """Build the final battery-level summary payload."""
+    rejected_tests = [name for name, outcome in tests.items() if outcome.reject_null is True]
+
+    runs_outcome = tests.get("runs_test_signs")
+    sign_rejected = bool(runs_outcome.reject_null is True) if runs_outcome is not None else False
+
+    mean_rejected = bool(
+        tests["variance_ratio_holm"].reject_null or tests["ljung_box_returns"].reject_null
+    )
+    volatility_rejected = bool(
+        tests["ljung_box_squared_returns"].reject_null or tests["arch_lm"].reject_null
+    )
+
+    weak_form_evidence_against_null = bool(
+        mean_rejected or sign_rejected or volatility_rejected
+    )
+
+    return {
+        "rejected_tests": rejected_tests,
+        "n_rejections": len(rejected_tests),
+        "mean_dependence_rejected": mean_rejected,
+        "sign_dependence_rejected": sign_rejected,
+        "volatility_dependence_rejected": volatility_rejected,
+        "weak_form_evidence_against_null": weak_form_evidence_against_null,
+    }
+
+
+def run_weak_form_battery(series, config: BatteryConfig | None = None) -> BatteryOutcome:
+    """Run the weak-form efficiency battery v1 and return structured outcomes."""
+    if config is None:
+        config = BatteryConfig()
+
+    normalized = normalize_series(series, input_kind=config.input_kind)
+    _validate_battery_compatibility(normalized, config)
+
+    tests: dict[str, TestOutcome] = {}
+
+    vr_family = _run_variance_ratio_family(normalized, config)
+    tests.update(vr_family)
+
+    vr_list = [tests[f"variance_ratio_q{q}"] for q in config.q_list]
+    holm_summary = _apply_holm_bonferroni(vr_list, config.alpha)
+    tests["variance_ratio_holm"] = TestOutcome(
+        name="variance_ratio_holm",
+        null_hypothesis="No variance-ratio horizon rejects after Holm-Bonferroni correction.",
+        statistic=None,
+        p_value=None,
+        alpha=config.alpha,
+        reject_null=bool(holm_summary["any_reject"]),
+        metadata=holm_summary,
+        warnings=[],
+    )
+
+    tests["ljung_box_returns"] = _run_ljung_box(
+        series=normalized.returns,
+        lags=config.ljung_box_lags,
+        alpha=config.alpha,
+        name="ljung_box_returns",
+        null_hypothesis="Returns are serially independent up to the tested lags.",
+    )
+
+    tests["ljung_box_squared_returns"] = _run_ljung_box(
+        series=normalized.squared_returns,
+        lags=config.ljung_box_lags,
+        alpha=config.alpha,
+        name="ljung_box_squared_returns",
+        null_hypothesis="Squared returns are serially independent up to the tested lags.",
+    )
+
+    if config.runs_test is True:
+        tests["runs_test_signs"] = _run_runs_test(normalized=normalized, alpha=config.alpha)
+
+    tests["arch_lm"] = _run_arch_lm(
+        returns=normalized.returns,
+        nlags=config.arch_lm_lags,
+        alpha=config.alpha,
+    )
+
+    multiple_testing = {
+        "variance_ratio_holm": holm_summary,
+        "battery_summary": _build_battery_summary(tests),
+    }
+
+    warnings: list[str] = []
+    for outcome in tests.values():
+        warnings.extend(outcome.warnings)
+
+    return BatteryOutcome(
+        input_kind=config.input_kind,
+        n_obs=normalized.n_raw,
+        returns_n_obs=normalized.n_returns,
+        tests=tests,
+        multiple_testing=multiple_testing,
+        rolling=None,
+        warnings=warnings,
+    )
+
+
+__all__ = ["run_weak_form_battery"]

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,0 +1,318 @@
+"""Tests for weak-form battery orchestration (Sprint 3)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from variance_test import BatteryConfig, BatteryOutcome, run_weak_form_battery
+
+
+def _iid_returns(seed: int, size: int, scale: float = 0.01) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.normal(0.0, scale, size=size)
+
+
+def _ar1_returns(seed: int, size: int, phi: float, sigma: float = 0.01) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    eps = rng.normal(0.0, sigma, size=size)
+    series = np.zeros(size, dtype=float)
+    for idx in range(1, size):
+        series[idx] = phi * series[idx - 1] + eps[idx]
+    return series
+
+
+def _arch_like_returns(seed: int, size: int, omega: float = 0.00001, alpha1: float = 0.85) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    shocks = rng.normal(0.0, 1.0, size=size)
+    returns = np.zeros(size, dtype=float)
+    sigma2 = np.zeros(size, dtype=float)
+    sigma2[0] = omega / (1 - alpha1)
+
+    for idx in range(1, size):
+        sigma2[idx] = omega + alpha1 * (returns[idx - 1] ** 2)
+        returns[idx] = shocks[idx] * np.sqrt(sigma2[idx])
+
+    return returns
+
+
+def test_run_weak_form_battery_importable_from_variance_test() -> None:
+    """run_weak_form_battery must be available from package root."""
+    assert run_weak_form_battery is not None
+
+
+def test_minimal_execution_returns_battery_outcome() -> None:
+    """A minimal execution on IID returns should produce BatteryOutcome."""
+    returns = _iid_returns(seed=100, size=800)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4), ljung_box_lags=(5, 10), arch_lm_lags=5)
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert isinstance(outcome, BatteryOutcome)
+
+
+def test_battery_tests_keys_exact_for_runs_enabled() -> None:
+    """The tests mapping must contain exactly the required keys when runs_test is True."""
+    returns = _iid_returns(seed=101, size=900)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4, 8),
+        ljung_box_lags=(5, 10),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert list(outcome.tests.keys()) == [
+        "variance_ratio_q2",
+        "variance_ratio_q4",
+        "variance_ratio_q8",
+        "variance_ratio_holm",
+        "ljung_box_returns",
+        "ljung_box_squared_returns",
+        "runs_test_signs",
+        "arch_lm",
+    ]
+
+
+def test_returns_and_log_prices_equivalence_for_core_outcomes() -> None:
+    """Equivalent returns and synthetic log-prices must produce equal core outcomes."""
+    returns = _iid_returns(seed=102, size=1200)
+    log_prices = np.concatenate(([0.0], np.cumsum(returns)))
+
+    config_returns = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+    config_log_prices = BatteryConfig(
+        input_kind="log_prices",
+        q_list=(2, 4),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    out_returns = run_weak_form_battery(returns, config=config_returns)
+    out_log_prices = run_weak_form_battery(log_prices, config=config_log_prices)
+
+    comparable = [
+        "variance_ratio_q2",
+        "variance_ratio_q4",
+        "ljung_box_returns",
+        "ljung_box_squared_returns",
+        "runs_test_signs",
+        "arch_lm",
+    ]
+    for name in comparable:
+        left = out_returns.tests[name]
+        right = out_log_prices.tests[name]
+
+        if left.statistic is None or right.statistic is None:
+            assert left.statistic is right.statistic
+        else:
+            assert np.isclose(left.statistic, right.statistic, atol=1e-10, rtol=1e-8)
+
+        if left.p_value is None or right.p_value is None:
+            assert left.p_value is right.p_value
+        else:
+            assert np.isclose(left.p_value, right.p_value, atol=1e-10, rtol=1e-8)
+
+        assert left.reject_null == right.reject_null
+
+    assert (
+        out_returns.tests["variance_ratio_holm"].reject_null
+        == out_log_prices.tests["variance_ratio_holm"].reject_null
+    )
+
+
+def test_iid_gaussian_alpha_001_non_rejection_for_selected_tests() -> None:
+    """IID Gaussian data should not reject selected tests at alpha=0.01."""
+    returns = _iid_returns(seed=12345, size=5000)
+    config = BatteryConfig(
+        input_kind="returns",
+        alpha=0.01,
+        q_list=(2, 4, 8),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert outcome.tests["variance_ratio_holm"].reject_null is False
+    assert outcome.tests["ljung_box_returns"].reject_null is False
+    assert outcome.tests["runs_test_signs"].reject_null is False
+    assert outcome.tests["arch_lm"].reject_null is False
+
+
+def test_ar1_detects_serial_dependence() -> None:
+    """AR(1) data should reject return dependence and VR family summary."""
+    returns = _ar1_returns(seed=456, size=4000, phi=0.3)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4, 8),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert outcome.tests["ljung_box_returns"].reject_null is True
+    vr_rejections = [
+        outcome.tests[f"variance_ratio_q{q}"].reject_null for q in config.q_list
+    ]
+    assert any(vr_rejections)
+    assert outcome.tests["variance_ratio_holm"].reject_null is True
+
+
+def test_arch_like_detects_volatility_dependence() -> None:
+    """ARCH-like data should reject squared-return dependence and ARCH LM."""
+    returns = _arch_like_returns(seed=789, size=5000)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4, 8),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert outcome.tests["ljung_box_squared_returns"].reject_null is True
+    assert outcome.tests["arch_lm"].reject_null is True
+
+
+def test_alternating_signs_reject_runs_test() -> None:
+    """Alternating signs should reject runs test randomness."""
+    returns = np.tile(np.array([0.01, -0.01]), 800)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4),
+        ljung_box_lags=(5, 10),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert outcome.tests["runs_test_signs"].reject_null is True
+
+
+def test_all_zero_returns_make_runs_test_not_computable() -> None:
+    """All-zero returns should produce non-computable runs test outcome."""
+    returns = np.zeros(500, dtype=float)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4),
+        ljung_box_lags=(5, 10),
+        runs_test=True,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+    runs_test = outcome.tests["runs_test_signs"]
+
+    assert runs_test.statistic is None
+    assert runs_test.p_value is None
+    assert runs_test.reject_null is None
+    assert runs_test.warnings
+
+
+def test_raises_for_incompatible_q_list() -> None:
+    """Incompatible q_list values must raise ValueError."""
+    returns = _iid_returns(seed=200, size=5)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 6), ljung_box_lags=(1,), arch_lm_lags=1)
+
+    with pytest.raises(ValueError):
+        run_weak_form_battery(returns, config=config)
+
+
+def test_raises_for_incompatible_ljung_box_lags() -> None:
+    """Incompatible Ljung-Box lags must raise ValueError."""
+    returns = _iid_returns(seed=201, size=10)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4), ljung_box_lags=(5, 10), arch_lm_lags=3)
+
+    with pytest.raises(ValueError):
+        run_weak_form_battery(returns, config=config)
+
+
+def test_raises_for_incompatible_arch_lm_lags() -> None:
+    """Incompatible ARCH LM lags must raise ValueError."""
+    returns = _iid_returns(seed=202, size=8)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4), ljung_box_lags=(2, 3), arch_lm_lags=8)
+
+    with pytest.raises(ValueError):
+        run_weak_form_battery(returns, config=config)
+
+
+def test_runs_key_absent_when_disabled() -> None:
+    """runs_test_signs must be absent when runs_test=False."""
+    returns = _iid_returns(seed=300, size=1000)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(2, 4, 8),
+        ljung_box_lags=(5, 10),
+        runs_test=False,
+        arch_lm_lags=5,
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert "runs_test_signs" not in outcome.tests
+
+
+def test_multiple_testing_keys_exact() -> None:
+    """multiple_testing must contain exactly the required keys."""
+    returns = _iid_returns(seed=301, size=1000)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4), ljung_box_lags=(5, 10), arch_lm_lags=5)
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    assert set(outcome.multiple_testing.keys()) == {"variance_ratio_holm", "battery_summary"}
+
+
+def test_battery_summary_keys_exact() -> None:
+    """battery_summary must contain exactly the required keys."""
+    returns = _iid_returns(seed=302, size=1000)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4), ljung_box_lags=(5, 10), arch_lm_lags=5)
+
+    outcome = run_weak_form_battery(returns, config=config)
+    summary = outcome.multiple_testing["battery_summary"]
+
+    assert set(summary.keys()) == {
+        "rejected_tests",
+        "n_rejections",
+        "mean_dependence_rejected",
+        "sign_dependence_rejected",
+        "volatility_dependence_rejected",
+        "weak_form_evidence_against_null",
+    }
+
+
+def test_all_computable_p_values_in_unit_interval() -> None:
+    """All computable p-values must lie in [0, 1]."""
+    returns = _iid_returns(seed=303, size=1200)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4, 8), ljung_box_lags=(5, 10), arch_lm_lags=5)
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    for test_outcome in outcome.tests.values():
+        if test_outcome.p_value is not None:
+            assert 0.0 <= test_outcome.p_value <= 1.0
+
+
+def test_reject_null_is_consistent_with_p_value_and_alpha() -> None:
+    """Each computable reject_null must be equivalent to p_value < alpha."""
+    returns = _iid_returns(seed=304, size=1200)
+    config = BatteryConfig(input_kind="returns", q_list=(2, 4, 8), ljung_box_lags=(5, 10), arch_lm_lags=5)
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    for test_outcome in outcome.tests.values():
+        if test_outcome.p_value is not None:
+            assert test_outcome.reject_null == (test_outcome.p_value < test_outcome.alpha)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -14,6 +14,7 @@ from variance_test import (
     compute_vrt_statistics,
     normalize_series,
     run_simulation,
+    run_weak_form_battery,
     simulate_price_processes,
 )
 import variance_test
@@ -33,6 +34,7 @@ EXPECTED_PUBLIC_API = {
     "BatteryConfig",
     "TestOutcome",
     "BatteryOutcome",
+    "run_weak_form_battery",
 }
 
 
@@ -64,6 +66,11 @@ def test_new_data_contract_api_importable_from_root() -> None:
     assert TestOutcome is not None
     assert BatteryOutcome is not None
 
+
+
+def test_run_weak_form_battery_importable_from_root() -> None:
+    """run_weak_form_battery must be importable from package root."""
+    assert run_weak_form_battery is not None
 
 def test_all_contains_exact_public_api() -> None:
     """__all__ must match the required minimal API exactly."""


### PR DESCRIPTION
### Motivation
- Add the Sprint 3 weak-form efficiency battery v1 as a single public entry point to execute a deterministic set of weak-form tests.
- Reuse existing package contracts and the `EMH.vrt(...)` implementation without reimplementing the VRT logic, and expose a programmatic summary for automated workflows.

### Description
- Added `src/variance_test/battery.py` implementing `run_weak_form_battery(...)` and private helpers `_validate_battery_compatibility`, `_run_variance_ratio_family`, `_apply_holm_bonferroni`, `_run_ljung_box`, `_run_runs_test`, `_run_arch_lm`, and `_build_battery_summary` that implement the exact battery flow and output contracts specified in Sprint 3.
- The VR family reuses `EMH().vrt(...)` with the exact arguments required, and Holm-Bonferroni is implemented per the specified step-down algorithm and returned as `multiple_testing["variance_ratio_holm"]`.
- Added `run_weak_form_battery` export to `src/variance_test/__init__.py`, added `statsmodels` to `project.dependencies` in `pyproject.toml`, and updated `README.md` minimally to document the battery, example usage, interpretation warning, and note that `rolling = None`.
- Added `tests/test_battery.py` implementing the 17 deterministic tests required by the sprint and updated `tests/test_public_api.py` to include and assert `run_weak_form_battery` in the package API.

### Testing
- Attempted to install the package in editable mode with `python -m pip install -e .`, but installation failed due to network/proxy restrictions in the execution environment when resolving build dependencies (not a code failure).
- Ran `pytest -q` in this environment, which aborted during collection because runtime dependencies (e.g., `numpy`) are not available in the environment; therefore tests could not be executed here despite the test suite being added.
- The repository now contains the new unit tests (`tests/test_battery.py`) and updated public API tests (`tests/test_public_api.py`), ready to run in an environment with `numpy`, `scipy`, and `statsmodels` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6e4367dcc8323b45244474e66ec11)