### PR TITLE
Sprint 6: add opt-in robust variance-ratio diagnostics and release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,30 @@
 
 This file documents relevant project changes for public releases.
 
-## [0.1.0] - YYYY-MM-DD
+## [0.2.0] - 2026-04-09
+
+### Added
+
+- Opt-in robust variance-ratio family for weak-form battery execution.
+- Automatic variance-ratio test (`avr`) with AR(1) plug-in horizon selection.
+- Wild-bootstrap automatic variance-ratio test (`wbavr`) with deterministic seed support.
+- Chow-Denning-style max test (`chow_denning`) using Sidak-normal familywise calibration.
+- Internal diagnostics refactor under `variance_test.diagnostics` for extensible battery internals.
+- New robust test suite coverage and robust example script.
+
+### Changed
+
+- `BatteryConfig` now accepts optional `robust_vr=RobustVRConfig(...)`.
+- Robust diagnostics are disabled by default and run only when explicitly enabled.
+- Full-sample v1 battery behavior remains unchanged when robust diagnostics are not enabled.
+
+### Notes
+
+- Rolling scope is unchanged: robust tests are full-sample only in this release.
+- Structural-break and long-memory diagnostics are not included yet.
+- `chow_denning` in this release is Sidak-normal calibrated and is not exact SMM calibration.
+
+## [0.1.0] - 2026-03-15
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -6,30 +6,19 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/LautaroParada/variance-test?style=flat)](https://github.com/LautaroParada/variance-test/commits/master)
 [![License](https://img.shields.io/github/license/LautaroParada/variance-test?style=flat)](https://github.com/LautaroParada/variance-test/blob/master/LICENSE)
 
-Testing whether a return series is compatible with a random walk usually means stitching together a variance ratio implementation, a Ljung-Box call, an ARCH-LM check, a runs test, and some ad-hoc glue code to normalize inputs and interpret results. Then you repeat it for rolling windows. Then you do it again for the next asset.
-
-`variance-test` replaces that workflow with a single structured call.
+`variance-test` is an offline Python package for weak-form efficiency diagnostics on return series. It provides classic variance-ratio testing and a structured weak-form battery with optional robust variance-ratio tools.
 
 ```python
 from variance_test import BatteryConfig, run_weak_form_battery
 
 outcome = run_weak_form_battery(returns, config=BatteryConfig(input_kind="returns"))
-
 print(outcome.multiple_testing["battery_summary"])
 ```
-
-One call. Structured output. Mean dependence, sign dependence, volatility dependence, and multiple testing correction included.
 
 ## Installation
 
 ```bash
 pip install variance-test
-```
-
-For development:
-
-```bash
-pip install -e .
 ```
 
 ## Quick start
@@ -59,7 +48,7 @@ print("z_score:", z_score)
 print("p_value:", p_value)
 ```
 
-### Full weak-form battery
+### Full weak-form battery (classic)
 
 ```python
 import numpy as np
@@ -78,11 +67,7 @@ config = BatteryConfig(
 )
 
 outcome = run_weak_form_battery(returns, config=config)
-
-# Holm-corrected VR family decision
 print("VR family rejects:", outcome.tests["variance_ratio_holm"].reject_null)
-
-# Full battery summary
 print(outcome.multiple_testing["battery_summary"])
 ```
 
@@ -106,38 +91,48 @@ config = BatteryConfig(
 )
 
 outcome = run_weak_form_battery(returns, config=config)
-
 print("n_windows:", outcome.rolling["n_windows"])
 print("first_vr_windows:", outcome.rolling["tests"]["variance_ratio_q2"][:2])
 ```
 
-### Empirical application
+## Robust variance-ratio tools (v0.2.0)
+
+Release `0.2.0` adds an **opt-in** robust VR family via `RobustVRConfig`:
+
+- `avr` (automatic variance-ratio)
+- `wbavr` (wild-bootstrap automatic variance-ratio)
+- `chow_denning` (Chow-Denning-style max test)
+
+Robust tests are disabled by default. Enable them explicitly:
 
 ```python
-import numpy as np
-from variance_test import EMH, BatteryConfig, run_weak_form_battery
+from variance_test import BatteryConfig, RobustVRConfig, run_weak_form_battery
 
-# Replace with your own data source
-prices = np.array([100.0, 101.5, 100.8, 102.2, 103.1, 101.9, ...])
-log_prices = np.log(prices)
-
-# Single test
-emh = EMH()
-z, p = emh.vrt(X=log_prices, q=5, input_kind="log_prices", heteroskedastic=True)
-print(f"VR test: z={z:.4f}, p={p:.4f}")
-
-# Full battery on returns
-returns = np.diff(log_prices)
 config = BatteryConfig(
     input_kind="returns",
     q_list=(2, 4, 8, 16),
-    ljung_box_lags=(5, 10, 20),
-    rolling_window=252,
-    rolling_step=21,
+    robust_vr=RobustVRConfig(
+        enabled=True,
+        enable_avr=True,
+        enable_wbavr=True,
+        enable_chow_denning=True,
+        bootstrap_reps=999,
+        bootstrap_seed=42,
+    ),
 )
+
 outcome = run_weak_form_battery(returns, config=config)
-print(outcome.multiple_testing["battery_summary"])
+print(outcome.multiple_testing["robust_vr_summary"])
 ```
+
+Important calibration note for this release:
+
+- `chow_denning` uses **Sidak-normal** familywise calibration (`"sidak_normal"`).
+- This is **not exact SMM calibration**.
+- Sidak-normal treats familywise tails as if built from independent normal tails.
+- Since per-q VR Z statistics come from overlapping data and are not independent, this is an approximation and should be described as conservative rather than exact.
+
+Rolling support for robust tests (`avr`, `wbavr`, `chow_denning`) is **not included** in `0.2.0`.
 
 ## What the battery includes
 
@@ -149,227 +144,23 @@ print(outcome.multiple_testing["battery_summary"])
 | Ljung-Box on squared returns | Serial dependence in volatility | Yes |
 | Runs test on signs | Non-random sign patterns | No |
 | ARCH LM | Conditional heteroskedasticity | No |
+| AVR | Automatic variance-ratio diagnostic | No |
+| WBAVR | Wild-bootstrap automatic variance-ratio diagnostic | No |
+| chow_denning | Chow-Denning-style max family diagnostic | No |
 
-The battery output classifies rejections into three categories: **mean dependence**, **sign dependence**, and **volatility dependence**. The summary field aggregates these into a single `weak_form_evidence_against_null` flag.
+The battery provides statistical evidence under its implemented diagnostics. Rejection does not prove market inefficiency.
 
 ## Input formats
 
-The package accepts two input modes:
+- `input_kind="returns"` for one-period log-returns.
+- `input_kind="log_prices"` for cumulative log-prices.
 
-* `input_kind="returns"` for one-period log-returns
-* `input_kind="log_prices"` for cumulative log-price series
+The package normalizes both pathways consistently.
 
-Both modes produce identical test statistics for equivalent data. This is tested and enforced in the test suite.
+## References
 
-If you have raw prices:
-
-```python
-import numpy as np
-
-prices = np.array([100.0, 101.5, 100.8, 102.2])
-log_prices = np.log(prices)
-returns = np.diff(log_prices)
-```
-
-## Main interfaces
-
-### `EMH().vrt(...)`
-
-Low-level variance ratio test.
-
-| Parameter | Description |
-|---|---|
-| `X` | 1-D input series |
-| `q` | Aggregation horizon |
-| `input_kind` | `"returns"` or `"log_prices"` |
-| `heteroskedastic` | Use heteroskedastic asymptotic variance (Lo & MacKinlay Z2) |
-| `centered` | Centered statistic |
-| `unbiased` | Unbiased variance/autocovariance estimators |
-| `annualize` | Scaling flag for intermediate volatility estimators |
-| `alternative` | `"two-sided"`, `"greater"`, or `"less"` |
-
-Returns `(z_score, p_value)`.
-
-### `normalize_series(...)`
-
-Shared normalization used internally. Exposed for users who want direct access to the canonical representation.
-
-```python
-from variance_test import normalize_series
-
-ns = normalize_series([0.01, -0.02, 0.015], input_kind="returns")
-# ns.log_prices, ns.returns, ns.squared_returns, ns.signs, ns.n_returns
-```
-
-### `run_weak_form_battery(...)`
-
-Full diagnostic pass. Returns a `BatteryOutcome` with:
-
-* `tests` -- individual `TestOutcome` objects per test
-* `multiple_testing` -- Holm summary and battery summary
-* `rolling` -- rolling-window results (when configured)
-* `warnings` -- non-computable test warnings
-
-## How to read the results
-
-**Variance ratio:** `VR(q) > 1` suggests positive serial dependence. `VR(q) < 1` suggests mean reversion. `VR(q) ≈ 1` is compatible with the random walk null.
-
-**p-values:** Low p-value means the data is less compatible with the null hypothesis.
-
-**Battery summary:** The battery provides statistical evidence against compatibility with weak-form efficiency under its test design. It does not constitute proof of market inefficiency. A rejection means the series shows detectable structure under the selected diagnostics.
-
-## Implementation details
-
-### Variance ratio estimator
-
-The implementation uses **overlapping q-period increments** for the q-period variance estimator:
-
-```
-σ²_a(q) = (1 / ((n_q - 1) · q)) · Σ (X_{t} - X_{t-q} - q·μ̂)²
-```
-
-where the sum runs over all overlapping windows `t = q, q+1, ..., T`, and `μ̂ = (X_T - X_0) / T`.
-
-The one-period variance estimator uses standard first differences:
-
-```
-σ²_b = (1 / (n₁ - 1)) · Σ (X_{t} - X_{t-1} - μ̂)²
-```
-
-The centered ratio is `M_r(q) = (σ²_a / σ²_b) - 1`.
-
-Under the **homoskedastic null** (Lo & MacKinlay Z1), the asymptotic variance is `2(2q-1)(q-1) / (3q)`.
-
-Under the **heteroskedastic null** (Lo & MacKinlay Z2), the asymptotic variance uses the `δ̂(j)` estimator:
-
-```
-δ̂(j) = (nq · Σ (ΔX_{t} - μ̂)² · (ΔX_{t-j} - μ̂)²) / (Σ (ΔX_{t} - μ̂)²)²
-```
-
-with weights `(2(q-j)/q)²` for `j = 1, ..., q-1`.
-
-Edge cases where `q < 2`, sample sizes are insufficient, or variance estimates are non-positive raise explicit `ValueError` exceptions instead of producing silent NaN or incorrect results.
-
-### References
-
-* Lo, A.W. and MacKinlay, A.C. "Stock Market Prices Do Not Follow Random Walks: Evidence from a Simple Specification Test." *Review of Financial Studies*, 1(1), 1988.
-* Lo, A.W. and MacKinlay, A.C. "The Size and Power of the Variance Ratio Test in Finite Samples: A Monte Carlo Investigation." *Journal of Econometrics*, 40(2), 1989.
-
-## Correctness and testing
-
-The implementation was [audited for statistical correctness](AUDIT.md). Three issues were identified and resolved:
-
-1. **σ²_a estimator ignoring q-aggregation** (severity: high) -- the original loop computed first differences regardless of `q`. Fixed with overlapping q-period differences using `X[t] - X[t-q]`.
-2. **Division by zero in unbiased σ²_b adjustment** (severity: medium) -- when `len(X) == q`, the denominator `m` collapsed to zero. Fixed with explicit validation that degrees of freedom are positive before division.
-3. **v̂ degenerate for q < 3** (severity: medium) -- for `q = 1` or `q = 2`, the summation range in the heteroskedastic estimator was empty, producing `v̂ = 0` and a subsequent division by zero. Fixed with an explicit guard requiring `q ≥ 2` and `v̂ > 0`.
-
-The package is covered by an automated test suite that validates calibration, detection, edge cases, rolling-window behavior, and input-mode equivalence. Key coverage includes:
-
-* IID Gaussian non-rejection at α=0.01 for the selected battery components covered by the test suite (`variance_ratio_holm`, `ljung_box_returns`, `runs_test_signs`, `arch_lm`)
-* AR(1) detection of serial dependence with VR family and Ljung-Box rejection
-* ARCH-like data detection of volatility clustering via Ljung-Box squared returns and ARCH LM
-* Alternating sign rejection via runs test
-* Exact equivalence between `returns` and `log_prices` input modes for all comparable test outcomes
-* p-value/reject_null consistency enforcement in all TestOutcome instances
-* Rolling window index monotonicity, count formulas, and non-computable window handling
-* Edge cases: all-zero returns, insufficient samples, incompatible lag/horizon combinations
-
-CI runs on Python 3.11 and 3.12 on every push and pull request.
-
-## Simulation support
-
-The package includes simulation utilities for synthetic experimentation.
-
-```python
-from variance_test import SimulationConfig, run_simulation
-
-config = SimulationConfig(
-    num_series=5,
-    horizon=200,
-    initial_price=100.0,
-    mu=0.05,
-    sigma=0.2,
-    aggregation_horizon=2,
-    heteroskedastic=False,
-    seed=42,
-)
-
-results = run_simulation(config)
-print(f"Mean z-score: {results.z_scores.mean():.4f}")
-print(f"Mean p-value: {results.p_values.mean():.4f}")
-```
-
-Included stochastic processes: Geometric Brownian Motion, Merton Jump Diffusion, Heston Stochastic Volatility, Vasicek, Cox-Ingersoll-Ross, Ornstein-Uhlenbeck.
-
-CLI:
-
-```bash
-python -m variance_test.simulation --series 10 --horizon 100 --aggregation 3 --seed 42 --no-plot
-```
-
-## Package architecture
-
-```mermaid
-flowchart TD
-    A[User input series] --> B{input_kind}
-    B -->|returns| C[normalize_series]
-    B -->|log_prices| C
-
-    C --> D[EMH.vrt]
-    C --> E[run_weak_form_battery]
-
-    E --> F[Variance ratio family]
-    E --> G[Holm summary]
-    E --> H[Ljung-Box returns]
-    E --> I[Ljung-Box squared returns]
-    E --> J[Runs test on signs]
-    E --> K[ARCH LM]
-    E --> L[Rolling results for supported tests]
-```
-
-## Public API
-
-```mermaid
-flowchart LR
-    A[variance_test] --> B[EMH]
-    A --> C[normalize_series]
-    A --> D[run_weak_form_battery]
-    A --> E[SimulationConfig]
-    A --> F[run_simulation]
-    A --> G[PricePaths]
-    A --> H[VRTVisuals]
-```
-
-## Examples
-
-### Offline examples (self-contained, no external dependencies)
-
-* `examples/basic_battery.py` -- full-sample battery
-* `examples/rolling_battery.py` -- rolling-window battery
-* `examples/variance_ratio_only.py` -- standalone VRT
-
-### External-data example (requires API credentials)
-
-* `examples/empirical_application.py` -- empirical VRT on market data via [EOD Historical Data](https://eodhistoricaldata.com/). Requires `eod` package and `API_EOD` environment variable.
-
-## Citation
-
-### BibTeX
-
-```bibtex
-@software{parada_variance_test_2026,
-  title = {variance-test},
-  author = {Parada, Lautaro},
-  year = {2026},
-  url = {https://github.com/LautaroParada/variance-test},
-  note = {Python package for variance ratio testing and weak-form efficiency diagnostics}
-}
-```
-
-### Plain text
-
-Parada, Lautaro. `variance-test`. Python package for variance ratio testing and weak-form efficiency diagnostics. GitHub repository: [https://github.com/LautaroParada/variance-test](https://github.com/LautaroParada/variance-test)
-
-## License
-
-MIT. See [LICENSE](LICENSE).
+- Lo, A.W. and MacKinlay, A.C. (1988). *Stock Market Prices Do Not Follow Random Walks: Evidence from a Simple Specification Test.*
+- Lo, A.W. and MacKinlay, A.C. (1989). *The Size and Power of the Variance Ratio Test in Finite Samples: A Monte Carlo Investigation.*
+- Choi, I. (1999). *Testing the random walk hypothesis for real exchange rates.* (Automatic variance-ratio framing.)
+- Kim, J.H. (2006). *Wild bootstrapping variance ratio tests.*
+- Chow, K.V. and Denning, K.C. (1993). *A simple multiple variance ratio test.* (This release uses a Chow-Denning-style framing with Sidak-normal approximation.)

--- a/examples/robust_battery.py
+++ b/examples/robust_battery.py
@@ -1,0 +1,41 @@
+"""Offline example for robust weak-form battery diagnostics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from variance_test import BatteryConfig, RobustVRConfig, run_weak_form_battery
+
+
+def main() -> None:
+    """Run robust battery on synthetic data and print robust outputs."""
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0, 0.01, size=5000)
+
+    config = BatteryConfig(
+        input_kind="returns",
+        alpha=0.05,
+        q_list=(2, 4, 8, 16),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+        robust_vr=RobustVRConfig(
+            enabled=True,
+            enable_avr=True,
+            enable_wbavr=True,
+            enable_chow_denning=True,
+            bootstrap_reps=999,
+            bootstrap_seed=42,
+        ),
+    )
+
+    outcome = run_weak_form_battery(returns, config=config)
+
+    print("AVR:", outcome.tests["avr"])
+    print("WBAVR:", outcome.tests["wbavr"])
+    print("CHOW_DENNING:", outcome.tests["chow_denning"])
+    print("robust_vr_summary:", outcome.multiple_testing["robust_vr_summary"])
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "variance-test"
-version = "0.1.0"
-description = "Variance Ratio Test utilities for stochastic price processes."
+version = "0.2.0"
+description = "Weak-form efficiency diagnostics with classic and robust variance-ratio support."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/src/variance_test/__init__.py
+++ b/src/variance_test/__init__.py
@@ -3,7 +3,7 @@
 from .battery import run_weak_form_battery
 from .core import EMH
 from .data import NormalizedSeries, normalize_series
-from .models import BatteryConfig, BatteryOutcome, TestOutcome
+from .models import BatteryConfig, BatteryOutcome, RobustVRConfig, TestOutcome
 from .price_paths import PricePaths
 from .simulation import (
     SimulationConfig,
@@ -26,6 +26,7 @@ __all__ = [
     "NormalizedSeries",
     "normalize_series",
     "BatteryConfig",
+    "RobustVRConfig",
     "TestOutcome",
     "BatteryOutcome",
     "run_weak_form_battery",

--- a/src/variance_test/battery.py
+++ b/src/variance_test/battery.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-import numpy as np
-from scipy import stats
-from statsmodels.stats import diagnostic
-
-from .core import EMH
 from .data import normalize_series
+from .diagnostics import (
+    _apply_holm_bonferroni,
+    _run_arch_lm,
+    _run_ljung_box,
+    _run_runs_test,
+    _run_variance_ratio_family,
+    make_non_computable_robust_outcome,
+    run_avr,
+    run_chow_denning,
+    run_wbavr,
+)
 from .models import BatteryConfig, BatteryOutcome, TestOutcome
 from .rolling import _build_rolling_results
 
@@ -25,312 +31,6 @@ def _validate_battery_compatibility(normalized, config: BatteryConfig) -> None:
 
     if config.arch_lm_lags >= normalized.n_returns:
         raise ValueError("config.arch_lm_lags must satisfy < normalized.n_returns.")
-
-
-def _run_variance_ratio_family(normalized, config: BatteryConfig) -> dict[str, TestOutcome]:
-    """Run multi-horizon variance ratio tests using EMH.vrt."""
-    emh = EMH()
-    outcomes: dict[str, TestOutcome] = {}
-
-    for q in config.q_list:
-        name = f"variance_ratio_q{q}"
-
-        try:
-            z_score, p_value = emh.vrt(
-                X=normalized.log_prices,
-                q=q,
-                heteroskedastic=True,
-                centered=True,
-                unbiased=True,
-                annualize=False,
-                input_kind="log_prices",
-                alternative="two-sided",
-            )
-
-            outcomes[name] = TestOutcome(
-                name=name,
-                null_hypothesis="Variance ratio equals 1 under the random walk null.",
-                statistic=float(z_score),
-                p_value=float(p_value),
-                alpha=config.alpha,
-                reject_null=bool(p_value < config.alpha),
-                metadata={
-                    "q": q,
-                    "heteroskedastic": True,
-                    "centered": True,
-                    "unbiased": True,
-                    "annualize": False,
-                    "input_kind_used": "log_prices",
-                    "alternative": "two-sided",
-                },
-                warnings=[],
-            )
-
-        except ValueError as exc:
-            outcomes[name] = TestOutcome(
-                name=name,
-                null_hypothesis="Variance ratio equals 1 under the random walk null.",
-                statistic=None,
-                p_value=None,
-                alpha=config.alpha,
-                reject_null=None,
-                metadata={
-                    "q": q,
-                    "heteroskedastic": True,
-                    "centered": True,
-                    "unbiased": True,
-                    "annualize": False,
-                    "input_kind_used": "log_prices",
-                    "alternative": "two-sided",
-                    "reason": str(exc),
-                },
-                warnings=[f"Variance ratio not computable for q={q}: {exc}"],
-            )
-
-    return outcomes
-
-
-def _apply_holm_bonferroni(vr_outcomes: list[TestOutcome], alpha: float) -> dict[str, object]:
-    """Apply Holm-Bonferroni correction to the variance-ratio family.
-
-    Non-computable tests (p_value is None) are treated as non-rejections and
-    are excluded from the step-down ordering, but still appear in the summary.
-    """
-    family = [outcome.name for outcome in vr_outcomes]
-    raw_p_values = {outcome.name: outcome.p_value for outcome in vr_outcomes}
-
-    computable = [outcome for outcome in vr_outcomes if outcome.p_value is not None]
-    sorted_outcomes = sorted(computable, key=lambda item: (float(item.p_value), item.name))
-    m = len(sorted_outcomes)
-
-    thresholds: dict[str, float | None] = {name: None for name in family}
-    rejections: dict[str, bool] = {name: False for name in family}
-
-    stop = False
-    for i, outcome in enumerate(sorted_outcomes):
-        threshold = alpha / (m - i)
-        thresholds[outcome.name] = float(threshold)
-
-        if stop:
-            rejections[outcome.name] = False
-            continue
-
-        if float(outcome.p_value) <= threshold:
-            rejections[outcome.name] = True
-        else:
-            rejections[outcome.name] = False
-            stop = True
-
-    return {
-        "method": "holm-bonferroni",
-        "family": family,
-        "raw_p_values": raw_p_values,
-        "sorted_tests": [outcome.name for outcome in sorted_outcomes],
-        "thresholds": thresholds,
-        "rejections": rejections,
-        "any_reject": any(rejections.values()),
-    }
-
-
-def _run_ljung_box(
-    series: np.ndarray,
-    lags: tuple[int, ...],
-    alpha: float,
-    name: str,
-    null_hypothesis: str,
-) -> TestOutcome:
-    """Run Ljung-Box test and select the lag with minimum p-value."""
-    result = diagnostic.acorr_ljungbox(series, lags=list(lags), return_df=True)
-
-    lb_stat = result["lb_stat"].to_numpy(dtype=float)
-    lb_pvalue = result["lb_pvalue"].to_numpy(dtype=float)
-
-    per_lag: dict[int, dict[str, float | bool]] = {}
-
-    finite_pairs = [
-        (int(lag), float(stat_value), float(p_value))
-        for lag, stat_value, p_value in zip(lags, lb_stat, lb_pvalue)
-        if np.isfinite(stat_value) and np.isfinite(p_value)
-    ]
-
-    if not finite_pairs:
-        return TestOutcome(
-            name=name,
-            null_hypothesis=null_hypothesis,
-            statistic=None,
-            p_value=None,
-            alpha=alpha,
-            reject_null=None,
-            metadata={
-                "tested_lags": list(lags),
-                "selected_lag": None,
-                "per_lag": {},
-                "reason": "Ljung-Box statistics are not finite for this series.",
-            },
-            warnings=[f"{name} not computable: Ljung-Box statistics are not finite."],
-        )
-
-    selected_lag, selected_stat, selected_p = min(finite_pairs, key=lambda x: (x[2], x[0]))
-
-    for lag, stat_value, p_value in finite_pairs:
-        per_lag[int(lag)] = {
-            "statistic": float(stat_value),
-            "p_value": float(p_value),
-            "reject_null": bool(p_value < alpha),
-        }
-
-    return TestOutcome(
-        name=name,
-        null_hypothesis=null_hypothesis,
-        statistic=float(selected_stat),
-        p_value=float(selected_p),
-        alpha=alpha,
-        reject_null=bool(selected_p < alpha),
-        metadata={
-            "tested_lags": list(lags),
-            "selected_lag": int(selected_lag),
-            "per_lag": per_lag,
-        },
-        warnings=[],
-    )
-
-def _run_runs_test(normalized, alpha: float) -> TestOutcome:
-    """Run bilateral Wald-Wolfowitz runs test over non-zero return signs."""
-    non_zero_returns = normalized.returns[normalized.returns != 0.0]
-    signs = np.sign(non_zero_returns)
-
-    n_effective = int(signs.size)
-    n_positive = int(np.sum(signs > 0))
-    n_negative = int(np.sum(signs < 0))
-
-    if n_effective < 2:
-        return TestOutcome(
-            name="runs_test_signs",
-            null_hypothesis="Signs of non-zero returns are random.",
-            statistic=None,
-            p_value=None,
-            alpha=alpha,
-            reject_null=None,
-            metadata={
-                "n_effective": n_effective,
-                "n_positive": n_positive,
-                "n_negative": n_negative,
-                "reason": "effective length is less than 2",
-            },
-            warnings=["Runs test not computable: effective length is less than 2."],
-        )
-
-    if n_positive == 0 or n_negative == 0:
-        return TestOutcome(
-            name="runs_test_signs",
-            null_hypothesis="Signs of non-zero returns are random.",
-            statistic=None,
-            p_value=None,
-            alpha=alpha,
-            reject_null=None,
-            metadata={
-                "n_effective": n_effective,
-                "n_positive": n_positive,
-                "n_negative": n_negative,
-                "reason": "both positive and negative signs are required",
-            },
-            warnings=["Runs test not computable: both sign classes are required."],
-        )
-
-    runs = int(1 + np.sum(signs[1:] != signs[:-1]))
-    expected_runs = 1 + (2 * n_positive * n_negative) / (n_positive + n_negative)
-    variance_runs = (
-        2
-        * n_positive
-        * n_negative
-        * (2 * n_positive * n_negative - n_positive - n_negative)
-        / (((n_positive + n_negative) ** 2) * (n_positive + n_negative - 1))
-    )
-
-    if variance_runs <= 0:
-        return TestOutcome(
-            name="runs_test_signs",
-            null_hypothesis="Signs of non-zero returns are random.",
-            statistic=None,
-            p_value=None,
-            alpha=alpha,
-            reject_null=None,
-            metadata={
-                "n_effective": n_effective,
-                "n_positive": n_positive,
-                "n_negative": n_negative,
-                "reason": "theoretical runs variance is non-positive",
-            },
-            warnings=["Runs test not computable: theoretical variance is non-positive."],
-        )
-
-    z_score = (runs - expected_runs) / np.sqrt(variance_runs)
-    p_value = 2 * (1 - stats.norm.cdf(abs(z_score)))
-
-    return TestOutcome(
-        name="runs_test_signs",
-        null_hypothesis="Signs of non-zero returns are random.",
-        statistic=float(z_score),
-        p_value=float(p_value),
-        alpha=alpha,
-        reject_null=bool(p_value < alpha),
-        metadata={
-            "n_effective": n_effective,
-            "n_positive": n_positive,
-            "n_negative": n_negative,
-            "runs": runs,
-            "expected_runs": float(expected_runs),
-            "variance_runs": float(variance_runs),
-        },
-        warnings=[],
-    )
-
-
-def _run_arch_lm(returns: np.ndarray, nlags: int, alpha: float) -> TestOutcome:
-    """Run ARCH LM test on returns."""
-    lm_stat, lm_p_value, f_stat, f_p_value = diagnostic.het_arch(returns, nlags=nlags)
-
-    values = [lm_stat, lm_p_value, f_stat, f_p_value]
-    if not all(np.isfinite(value) for value in values):
-        return TestOutcome(
-            name="arch_lm",
-            null_hypothesis="No ARCH effects are present up to the tested lag order.",
-            statistic=None,
-            p_value=None,
-            alpha=alpha,
-            reject_null=None,
-            metadata={
-                "nlags": nlags,
-                "lm_stat": None,
-                "lm_p_value": None,
-                "f_stat": None,
-                "f_p_value": None,
-                "reason": "ARCH LM statistics are not finite for this series.",
-            },
-            warnings=["arch_lm not computable: ARCH LM statistics are not finite."],
-        )
-
-    lm_stat = float(lm_stat)
-    lm_p_value = float(lm_p_value)
-    f_stat = float(f_stat)
-    f_p_value = float(f_p_value)
-
-    return TestOutcome(
-        name="arch_lm",
-        null_hypothesis="No ARCH effects are present up to the tested lag order.",
-        statistic=lm_stat,
-        p_value=lm_p_value,
-        alpha=alpha,
-        reject_null=bool(lm_p_value < alpha),
-        metadata={
-            "nlags": nlags,
-            "lm_stat": lm_stat,
-            "lm_p_value": lm_p_value,
-            "f_stat": f_stat,
-            "f_p_value": f_p_value,
-        },
-        warnings=[],
-    )
 
 
 def _build_battery_summary(tests: dict[str, TestOutcome]) -> dict[str, object]:
@@ -361,11 +61,67 @@ def _build_battery_summary(tests: dict[str, TestOutcome]) -> dict[str, object]:
     }
 
 
+def _append_robust_vr_tests(
+    tests: dict[str, TestOutcome],
+    normalized,
+    config: BatteryConfig,
+) -> dict[str, object]:
+    """Run robust VR tests if enabled and return robust summary payload."""
+    robust = config.robust_vr
+    if robust is None or robust.enabled is False:
+        return {}
+
+    robust_test_names: list[str] = []
+
+    robust_specs: tuple[tuple[bool, str, str, callable], ...] = (
+        (
+            robust.enable_avr,
+            "avr",
+            "The return process is compatible with the automatic variance-ratio random walk null.",
+            run_avr,
+        ),
+        (
+            robust.enable_wbavr,
+            "wbavr",
+            "The return process is compatible with the wild-bootstrap automatic variance-ratio random walk null.",
+            run_wbavr,
+        ),
+        (
+            robust.enable_chow_denning,
+            "chow_denning",
+            "All configured variance-ratio horizons are jointly compatible with the random walk null.",
+            run_chow_denning,
+        ),
+    )
+
+    for enabled, name, null_hypothesis, runner in robust_specs:
+        if not enabled:
+            continue
+        robust_test_names.append(name)
+        try:
+            tests[name] = runner(normalized, config)
+        except ValueError as exc:
+            tests[name] = make_non_computable_robust_outcome(
+                name=name,
+                null_hypothesis=null_hypothesis,
+                alpha=config.alpha,
+                reason=f"{name} not computable: {exc}",
+            )
+
+    rejected = [name for name in robust_test_names if tests[name].reject_null is True]
+    return {
+        "tests_included": robust_test_names,
+        "rejected_tests": rejected,
+        "n_rejections": len(rejected),
+        "any_reject": bool(rejected),
+    }
+
+
 def run_weak_form_battery(
     series,
     config: BatteryConfig | None = None,
 ) -> BatteryOutcome:
-    """Run the weak-form efficiency battery v1 and return structured outcomes."""
+    """Run the weak-form efficiency battery and return structured outcomes."""
     if config is None:
         config = BatteryConfig()
 
@@ -418,10 +174,14 @@ def run_weak_form_battery(
         alpha=config.alpha,
     )
 
+    robust_summary = _append_robust_vr_tests(tests=tests, normalized=normalized, config=config)
+
     multiple_testing = {
         "variance_ratio_holm": holm_summary,
         "battery_summary": _build_battery_summary(tests),
     }
+    if robust_summary:
+        multiple_testing["robust_vr_summary"] = robust_summary
 
     warnings: list[str] = []
     for outcome in tests.values():

--- a/src/variance_test/diagnostics/__init__.py
+++ b/src/variance_test/diagnostics/__init__.py
@@ -1,0 +1,28 @@
+"""Internal diagnostics helpers for battery orchestration."""
+
+from .arch_lm import _run_arch_lm
+from .ljung_box import _run_ljung_box
+from .robust_vr import (
+    _compute_heteroskedastic_z2_from_log_prices,
+    _compute_vr_value_from_log_prices,
+    make_non_computable_robust_outcome,
+    run_avr,
+    run_chow_denning,
+    run_wbavr,
+)
+from .runs import _run_runs_test
+from .vr_classic import _apply_holm_bonferroni, _run_variance_ratio_family
+
+__all__ = [
+    "_run_variance_ratio_family",
+    "_apply_holm_bonferroni",
+    "_run_ljung_box",
+    "_run_runs_test",
+    "_run_arch_lm",
+    "_compute_heteroskedastic_z2_from_log_prices",
+    "_compute_vr_value_from_log_prices",
+    "run_avr",
+    "run_wbavr",
+    "run_chow_denning",
+    "make_non_computable_robust_outcome",
+]

--- a/src/variance_test/diagnostics/arch_lm.py
+++ b/src/variance_test/diagnostics/arch_lm.py
@@ -1,0 +1,55 @@
+"""ARCH LM diagnostics used by the weak-form battery."""
+
+from __future__ import annotations
+
+import numpy as np
+from statsmodels.stats import diagnostic
+
+from variance_test.models import TestOutcome
+
+
+def _run_arch_lm(returns: np.ndarray, nlags: int, alpha: float) -> TestOutcome:
+    """Run ARCH LM test on returns."""
+    lm_stat, lm_p_value, f_stat, f_p_value = diagnostic.het_arch(returns, nlags=nlags)
+
+    values = [lm_stat, lm_p_value, f_stat, f_p_value]
+    if not all(np.isfinite(value) for value in values):
+        return TestOutcome(
+            name="arch_lm",
+            null_hypothesis="No ARCH effects are present up to the tested lag order.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "nlags": nlags,
+                "lm_stat": None,
+                "lm_p_value": None,
+                "f_stat": None,
+                "f_p_value": None,
+                "reason": "ARCH LM statistics are not finite for this series.",
+            },
+            warnings=["arch_lm not computable: ARCH LM statistics are not finite."],
+        )
+
+    lm_stat = float(lm_stat)
+    lm_p_value = float(lm_p_value)
+    f_stat = float(f_stat)
+    f_p_value = float(f_p_value)
+
+    return TestOutcome(
+        name="arch_lm",
+        null_hypothesis="No ARCH effects are present up to the tested lag order.",
+        statistic=lm_stat,
+        p_value=lm_p_value,
+        alpha=alpha,
+        reject_null=bool(lm_p_value < alpha),
+        metadata={
+            "nlags": nlags,
+            "lm_stat": lm_stat,
+            "lm_p_value": lm_p_value,
+            "f_stat": f_stat,
+            "f_p_value": f_p_value,
+        },
+        warnings=[],
+    )

--- a/src/variance_test/diagnostics/ljung_box.py
+++ b/src/variance_test/diagnostics/ljung_box.py
@@ -1,0 +1,71 @@
+"""Ljung-Box diagnostics used by the weak-form battery."""
+
+from __future__ import annotations
+
+import numpy as np
+from statsmodels.stats import diagnostic
+
+from variance_test.models import TestOutcome
+
+
+def _run_ljung_box(
+    series: np.ndarray,
+    lags: tuple[int, ...],
+    alpha: float,
+    name: str,
+    null_hypothesis: str,
+) -> TestOutcome:
+    """Run Ljung-Box test and select the lag with minimum p-value."""
+    result = diagnostic.acorr_ljungbox(series, lags=list(lags), return_df=True)
+
+    lb_stat = result["lb_stat"].to_numpy(dtype=float)
+    lb_pvalue = result["lb_pvalue"].to_numpy(dtype=float)
+
+    per_lag: dict[int, dict[str, float | bool]] = {}
+
+    finite_pairs = [
+        (int(lag), float(stat_value), float(p_value))
+        for lag, stat_value, p_value in zip(lags, lb_stat, lb_pvalue)
+        if np.isfinite(stat_value) and np.isfinite(p_value)
+    ]
+
+    if not finite_pairs:
+        return TestOutcome(
+            name=name,
+            null_hypothesis=null_hypothesis,
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "tested_lags": list(lags),
+                "selected_lag": None,
+                "per_lag": {},
+                "reason": "Ljung-Box statistics are not finite for this series.",
+            },
+            warnings=[f"{name} not computable: Ljung-Box statistics are not finite."],
+        )
+
+    selected_lag, selected_stat, selected_p = min(finite_pairs, key=lambda x: (x[2], x[0]))
+
+    for lag, stat_value, p_value in finite_pairs:
+        per_lag[int(lag)] = {
+            "statistic": float(stat_value),
+            "p_value": float(p_value),
+            "reject_null": bool(p_value < alpha),
+        }
+
+    return TestOutcome(
+        name=name,
+        null_hypothesis=null_hypothesis,
+        statistic=float(selected_stat),
+        p_value=float(selected_p),
+        alpha=alpha,
+        reject_null=bool(selected_p < alpha),
+        metadata={
+            "tested_lags": list(lags),
+            "selected_lag": int(selected_lag),
+            "per_lag": per_lag,
+        },
+        warnings=[],
+    )

--- a/src/variance_test/diagnostics/robust_vr.py
+++ b/src/variance_test/diagnostics/robust_vr.py
@@ -1,0 +1,337 @@
+"""Robust variance-ratio diagnostics for weak-form battery v0.2.0."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.stats import norm
+
+from variance_test.models import BatteryConfig, RobustVRConfig, TestOutcome
+
+
+def _compute_vr_value_from_log_prices(log_prices: np.ndarray, q: int) -> float:
+    """Compute centered variance-ratio value at horizon ``q`` from log-prices."""
+    prices = np.asarray(log_prices, dtype=float)
+    n_obs = prices.size
+    if q <= 0:
+        raise ValueError("Aggregation horizon q must be a positive integer.")
+    if n_obs <= q:
+        raise ValueError("Not enough observations for the requested aggregation horizon.")
+
+    mu_est = (prices[-1] - prices[0]) / n_obs
+
+    one_period_diffs = prices[1:] - prices[:-1] - mu_est
+    n_one = one_period_diffs.size
+    denom_b = n_one - 1
+    if denom_b <= 0:
+        raise ValueError("Degrees of freedom for one-period variance must be positive.")
+
+    sigma_b = float(np.dot(one_period_diffs, one_period_diffs)) / denom_b
+
+    q_period_diffs = prices[q:] - prices[:-q] - (q * mu_est)
+    n_q = q_period_diffs.size
+    denom_a = n_q - 1
+    if denom_a <= 0:
+        raise ValueError("Degrees of freedom for q-period variance must be positive.")
+
+    sigma_a = float(np.dot(q_period_diffs, q_period_diffs)) / (denom_a * q)
+
+    if sigma_a <= 0 or sigma_b <= 0:
+        raise ValueError("Variance estimates must be positive.")
+
+    return (sigma_a / sigma_b) - 1.0
+
+
+def _compute_heteroskedastic_z2_from_log_prices(log_prices: np.ndarray, q: int) -> float:
+    """Compute heteroskedastic Lo-MacKinlay Z2 at horizon ``q`` from log-prices."""
+    prices = np.asarray(log_prices, dtype=float)
+    if q < 2:
+        raise ValueError("q must be at least 2 for the heteroskedastic variance estimator.")
+    if prices.ndim != 1:
+        raise ValueError("log_prices must be one-dimensional.")
+
+    n = int(np.floor(prices.size / q))
+    if n <= 0:
+        raise ValueError("Not enough observations for the requested aggregation horizon.")
+
+    mr = _compute_vr_value_from_log_prices(prices, q=q)
+
+    upper_bound = n * q
+    if upper_bound <= q:
+        raise ValueError("Not enough observations to evaluate heteroskedastic variance.")
+
+    mu_est = (prices[-1] - prices[0]) / prices.size
+    diffs = prices[1:upper_bound] - prices[: upper_bound - 1] - mu_est
+    denominator = float(np.dot(diffs, diffs))
+    if denominator <= 0:
+        raise ValueError("Second moment of the differenced series is non-positive.")
+
+    v_hat = 0.0
+    for j in range(1, q):
+        lead = diffs[j:]
+        lagged = diffs[:-j]
+        numerator = float(np.dot(lead ** 2, lagged ** 2))
+        delta = (upper_bound * numerator) / (denominator ** 2)
+        weight = (2 * (q - j) / q) ** 2
+        v_hat += weight * delta
+
+    if v_hat <= 0:
+        raise ValueError("Asymptotic variance estimate must be positive.")
+
+    z2 = np.sqrt(n) * mr
+    return float(z2 / np.sqrt(v_hat))
+
+
+@dataclass(frozen=True)
+class _AutomaticQResult:
+    """Internal automatic-horizon selection payload for AVR-family tests."""
+
+    selected_q: int
+    q_raw: int
+    rho_hat: float
+    alpha_hat: float
+    warnings: list[str]
+
+
+def _select_automatic_q(returns: np.ndarray, max_automatic_q: int | None) -> _AutomaticQResult:
+    """Select automatic horizon using AR(1) plug-in bandwidth rule."""
+    r = np.asarray(returns, dtype=float)
+    n_returns = int(r.size)
+    if n_returns < 2:
+        raise ValueError("At least 2 returns are required for automatic horizon selection.")
+
+    r_demeaned = r - float(np.mean(r))
+    x = r_demeaned[:-1]
+    y = r_demeaned[1:]
+    denom = float(np.dot(x, x))
+    if denom <= 0:
+        rho_hat = 0.0
+    else:
+        rho_hat = float(np.dot(x, y) / denom)
+
+    if not np.isfinite(rho_hat):
+        rho_hat = 0.0
+
+    if abs(rho_hat) >= 0.97:
+        rho_hat = 0.97 if rho_hat >= 0 else -0.97
+
+    denom_alpha = (1 - rho_hat ** 2) ** 2
+    alpha_hat = (4 * rho_hat ** 2) / denom_alpha if denom_alpha > 0 else np.inf
+
+    if (not np.isfinite(alpha_hat)) or alpha_hat <= 0:
+        q_raw = 2
+    else:
+        q_raw = int(np.ceil(1.3221 * (alpha_hat * n_returns) ** (1 / 3)))
+
+    upper_candidate = max_automatic_q if max_automatic_q is not None else (n_returns // 2)
+    upper_bound = min(upper_candidate, n_returns - 1)
+    lower_bound = 2
+
+    if upper_bound < lower_bound:
+        raise ValueError(
+            "Sample too short to select automatic horizon with bounds requiring q >= 2."
+        )
+
+    selected_q = int(min(max(q_raw, lower_bound), upper_bound))
+
+    warnings: list[str] = []
+    if selected_q != q_raw:
+        warnings.append(
+            f"Automatic q_raw={q_raw} was clamped to selected_q={selected_q} within "
+            f"[{lower_bound}, {upper_bound}]."
+        )
+    if upper_bound == lower_bound:
+        warnings.append(
+            "Automatic horizon selection is dominated by sample-size upper-bound clamping."
+        )
+
+    return _AutomaticQResult(
+        selected_q=selected_q,
+        q_raw=int(q_raw),
+        rho_hat=float(rho_hat),
+        alpha_hat=float(alpha_hat),
+        warnings=warnings,
+    )
+
+
+def _resolve_chow_denning_q_list(config: BatteryConfig) -> tuple[int, ...]:
+    """Resolve q-family for Chow-Denning-style test from robust config or battery config."""
+    robust = config.robust_vr
+    if robust is None:
+        raise ValueError("robust_vr config is required for robust diagnostics.")
+    q_list = robust.q_list if robust.q_list is not None else config.q_list
+    if not q_list:
+        raise ValueError("Effective q_list cannot be empty.")
+    if any((not isinstance(q, int)) or q <= 0 for q in q_list):
+        raise ValueError("All effective q_list values must be positive integers.")
+    if any(curr <= prev for prev, curr in zip(q_list, q_list[1:])):
+        raise ValueError("Effective q_list must be strictly increasing.")
+    return tuple(q_list)
+
+
+def run_avr(normalized, config: BatteryConfig) -> TestOutcome:
+    """Run automatic variance-ratio (AVR) diagnostic."""
+    robust = _require_enabled_robust_config(config)
+    automatic = _select_automatic_q(normalized.returns, robust.max_automatic_q)
+
+    z_stat = _compute_heteroskedastic_z2_from_log_prices(
+        normalized.log_prices,
+        automatic.selected_q,
+    )
+    vr_value = _compute_vr_value_from_log_prices(normalized.log_prices, automatic.selected_q)
+    p_value = float(2 * (1 - norm.cdf(abs(z_stat))))
+
+    return TestOutcome(
+        name="avr",
+        null_hypothesis=(
+            "The return process is compatible with the automatic variance-ratio random walk null."
+        ),
+        statistic=float(z_stat),
+        p_value=p_value,
+        alpha=config.alpha,
+        reject_null=bool(p_value < config.alpha),
+        metadata={
+            "selected_q": automatic.selected_q,
+            "q_raw": automatic.q_raw,
+            "rho_hat": automatic.rho_hat,
+            "alpha_hat": automatic.alpha_hat,
+            "vr_value": float(vr_value),
+            "input_kind_used": "log_prices",
+            "automatic_rule": "ar1_plugin_1.3221",
+            "max_automatic_q": robust.max_automatic_q,
+        },
+        warnings=list(automatic.warnings),
+    )
+
+
+def run_wbavr(normalized, config: BatteryConfig) -> TestOutcome:
+    """Run wild-bootstrap automatic variance-ratio (WBAVR) diagnostic."""
+    robust = _require_enabled_robust_config(config)
+    automatic = _select_automatic_q(normalized.returns, robust.max_automatic_q)
+
+    selected_q = automatic.selected_q
+    observed_z = _compute_heteroskedastic_z2_from_log_prices(normalized.log_prices, selected_q)
+    vr_value = _compute_vr_value_from_log_prices(normalized.log_prices, selected_q)
+
+    centered_returns = normalized.returns - float(np.mean(normalized.returns))
+    rng = np.random.default_rng(robust.bootstrap_seed)
+    finite_bootstrap_stats: list[float] = []
+
+    for _ in range(robust.bootstrap_reps):
+        eta = rng.choice(np.array([-1.0, 1.0]), size=centered_returns.size)
+        bootstrap_returns = eta * centered_returns
+        bootstrap_log_prices = np.concatenate(([0.0], np.cumsum(bootstrap_returns)))
+
+        try:
+            z_star = _compute_heteroskedastic_z2_from_log_prices(bootstrap_log_prices, selected_q)
+        except ValueError:
+            continue
+
+        if np.isfinite(z_star):
+            finite_bootstrap_stats.append(float(z_star))
+
+    abs_obs = abs(float(observed_z))
+    exceedances = sum(abs(stat) >= abs_obs for stat in finite_bootstrap_stats)
+    p_value = float((1 + exceedances) / (robust.bootstrap_reps + 1))
+
+    quantiles = {
+        "q90": float(np.quantile(finite_bootstrap_stats, 0.90)) if finite_bootstrap_stats else None,
+        "q95": float(np.quantile(finite_bootstrap_stats, 0.95)) if finite_bootstrap_stats else None,
+        "q99": float(np.quantile(finite_bootstrap_stats, 0.99)) if finite_bootstrap_stats else None,
+    }
+
+    return TestOutcome(
+        name="wbavr",
+        null_hypothesis=(
+            "The return process is compatible with the wild-bootstrap automatic "
+            "variance-ratio random walk null."
+        ),
+        statistic=float(observed_z),
+        p_value=p_value,
+        alpha=config.alpha,
+        reject_null=bool(p_value < config.alpha),
+        metadata={
+            "selected_q": selected_q,
+            "bootstrap_reps": robust.bootstrap_reps,
+            "bootstrap_seed": robust.bootstrap_seed,
+            "wild_weights": robust.wild_weights,
+            "vr_value": float(vr_value),
+            "input_kind_used": "log_prices",
+            "bootstrap_quantiles": quantiles,
+            "n_bootstrap_effective": len(finite_bootstrap_stats),
+        },
+        warnings=list(automatic.warnings),
+    )
+
+
+def run_chow_denning(normalized, config: BatteryConfig) -> TestOutcome:
+    """Run Chow-Denning-style max test with Sidak-normal familywise calibration."""
+    robust = _require_enabled_robust_config(config)
+    q_list = _resolve_chow_denning_q_list(config)
+
+    per_q_statistics: dict[int, float] = {}
+    per_q_p_values: dict[int, float] = {}
+
+    for q in q_list:
+        z_q = _compute_heteroskedastic_z2_from_log_prices(normalized.log_prices, q)
+        p_q = float(2 * (1 - norm.cdf(abs(z_q))))
+        per_q_statistics[int(q)] = float(z_q)
+        per_q_p_values[int(q)] = p_q
+
+    max_abs_z = float(max(abs(z) for z in per_q_statistics.values()))
+    m = len(q_list)
+    p_single_max = float(2 * (1 - norm.cdf(max_abs_z)))
+    p_family = float(1 - (1 - p_single_max) ** m)
+
+    return TestOutcome(
+        name="chow_denning",
+        null_hypothesis=(
+            "All configured variance-ratio horizons are jointly compatible with the random walk null."
+        ),
+        statistic=max_abs_z,
+        p_value=p_family,
+        alpha=config.alpha,
+        reject_null=bool(p_family < config.alpha),
+        metadata={
+            "q_list": list(q_list),
+            "per_q_statistics": per_q_statistics,
+            "per_q_p_values": per_q_p_values,
+            "max_abs_z": max_abs_z,
+            "familywise_p_value": p_family,
+            "calibration": robust.chow_denning_calibration,
+            "input_kind_used": "log_prices",
+        },
+        warnings=[],
+    )
+
+
+def make_non_computable_robust_outcome(
+    name: str,
+    null_hypothesis: str,
+    alpha: float,
+    reason: str,
+) -> TestOutcome:
+    """Build standardized non-computable robust diagnostic outcome."""
+    return TestOutcome(
+        name=name,
+        null_hypothesis=null_hypothesis,
+        statistic=None,
+        p_value=None,
+        alpha=alpha,
+        reject_null=None,
+        metadata={"reason": reason},
+        warnings=[reason],
+    )
+
+
+def _require_enabled_robust_config(config: BatteryConfig) -> RobustVRConfig:
+    """Validate and return robust config when robust diagnostics are enabled."""
+    robust = config.robust_vr
+    if robust is None:
+        raise ValueError("robust_vr must be provided to run robust diagnostics.")
+    if not isinstance(robust, RobustVRConfig):
+        raise ValueError("robust_vr must be a RobustVRConfig instance.")
+    if robust.enabled is not True:
+        raise ValueError("robust_vr.enabled must be True to run robust diagnostics.")
+    return robust

--- a/src/variance_test/diagnostics/runs.py
+++ b/src/variance_test/diagnostics/runs.py
@@ -1,0 +1,100 @@
+"""Runs-test diagnostics used by the weak-form battery."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import stats
+
+from variance_test.models import TestOutcome
+
+
+def _run_runs_test(normalized, alpha: float) -> TestOutcome:
+    """Run bilateral Wald-Wolfowitz runs test over non-zero return signs."""
+    non_zero_returns = normalized.returns[normalized.returns != 0.0]
+    signs = np.sign(non_zero_returns)
+
+    n_effective = int(signs.size)
+    n_positive = int(np.sum(signs > 0))
+    n_negative = int(np.sum(signs < 0))
+
+    if n_effective < 2:
+        return TestOutcome(
+            name="runs_test_signs",
+            null_hypothesis="Signs of non-zero returns are random.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "n_effective": n_effective,
+                "n_positive": n_positive,
+                "n_negative": n_negative,
+                "reason": "effective length is less than 2",
+            },
+            warnings=["Runs test not computable: effective length is less than 2."],
+        )
+
+    if n_positive == 0 or n_negative == 0:
+        return TestOutcome(
+            name="runs_test_signs",
+            null_hypothesis="Signs of non-zero returns are random.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "n_effective": n_effective,
+                "n_positive": n_positive,
+                "n_negative": n_negative,
+                "reason": "both positive and negative signs are required",
+            },
+            warnings=["Runs test not computable: both sign classes are required."],
+        )
+
+    runs = int(1 + np.sum(signs[1:] != signs[:-1]))
+    expected_runs = 1 + (2 * n_positive * n_negative) / (n_positive + n_negative)
+    variance_runs = (
+        2
+        * n_positive
+        * n_negative
+        * (2 * n_positive * n_negative - n_positive - n_negative)
+        / (((n_positive + n_negative) ** 2) * (n_positive + n_negative - 1))
+    )
+
+    if variance_runs <= 0:
+        return TestOutcome(
+            name="runs_test_signs",
+            null_hypothesis="Signs of non-zero returns are random.",
+            statistic=None,
+            p_value=None,
+            alpha=alpha,
+            reject_null=None,
+            metadata={
+                "n_effective": n_effective,
+                "n_positive": n_positive,
+                "n_negative": n_negative,
+                "reason": "theoretical runs variance is non-positive",
+            },
+            warnings=["Runs test not computable: theoretical variance is non-positive."],
+        )
+
+    z_score = (runs - expected_runs) / np.sqrt(variance_runs)
+    p_value = 2 * (1 - stats.norm.cdf(abs(z_score)))
+
+    return TestOutcome(
+        name="runs_test_signs",
+        null_hypothesis="Signs of non-zero returns are random.",
+        statistic=float(z_score),
+        p_value=float(p_value),
+        alpha=alpha,
+        reject_null=bool(p_value < alpha),
+        metadata={
+            "n_effective": n_effective,
+            "n_positive": n_positive,
+            "n_negative": n_negative,
+            "runs": runs,
+            "expected_runs": float(expected_runs),
+            "variance_runs": float(variance_runs),
+        },
+        warnings=[],
+    )

--- a/src/variance_test/diagnostics/vr_classic.py
+++ b/src/variance_test/diagnostics/vr_classic.py
@@ -1,0 +1,107 @@
+"""Classic variance-ratio family diagnostics for battery orchestration."""
+
+from __future__ import annotations
+
+from variance_test.core import EMH
+from variance_test.models import BatteryConfig, TestOutcome
+
+
+def _run_variance_ratio_family(normalized, config: BatteryConfig) -> dict[str, TestOutcome]:
+    """Run multi-horizon variance-ratio tests with classic heteroskedastic Z2."""
+    emh = EMH()
+    outcomes: dict[str, TestOutcome] = {}
+
+    for q in config.q_list:
+        name = f"variance_ratio_q{q}"
+
+        try:
+            z_score, p_value = emh.vrt(
+                X=normalized.log_prices,
+                q=q,
+                heteroskedastic=True,
+                centered=True,
+                unbiased=True,
+                annualize=False,
+                input_kind="log_prices",
+                alternative="two-sided",
+            )
+
+            outcomes[name] = TestOutcome(
+                name=name,
+                null_hypothesis="Variance ratio equals 1 under the random walk null.",
+                statistic=float(z_score),
+                p_value=float(p_value),
+                alpha=config.alpha,
+                reject_null=bool(p_value < config.alpha),
+                metadata={
+                    "q": q,
+                    "heteroskedastic": True,
+                    "centered": True,
+                    "unbiased": True,
+                    "annualize": False,
+                    "input_kind_used": "log_prices",
+                    "alternative": "two-sided",
+                },
+                warnings=[],
+            )
+
+        except ValueError as exc:
+            outcomes[name] = TestOutcome(
+                name=name,
+                null_hypothesis="Variance ratio equals 1 under the random walk null.",
+                statistic=None,
+                p_value=None,
+                alpha=config.alpha,
+                reject_null=None,
+                metadata={
+                    "q": q,
+                    "heteroskedastic": True,
+                    "centered": True,
+                    "unbiased": True,
+                    "annualize": False,
+                    "input_kind_used": "log_prices",
+                    "alternative": "two-sided",
+                    "reason": str(exc),
+                },
+                warnings=[f"Variance ratio not computable for q={q}: {exc}"],
+            )
+
+    return outcomes
+
+
+def _apply_holm_bonferroni(vr_outcomes: list[TestOutcome], alpha: float) -> dict[str, object]:
+    """Apply Holm-Bonferroni correction to a variance-ratio test family."""
+    family = [outcome.name for outcome in vr_outcomes]
+    raw_p_values = {outcome.name: outcome.p_value for outcome in vr_outcomes}
+
+    computable = [outcome for outcome in vr_outcomes if outcome.p_value is not None]
+    sorted_outcomes = sorted(computable, key=lambda item: (float(item.p_value), item.name))
+    m = len(sorted_outcomes)
+
+    thresholds: dict[str, float | None] = {name: None for name in family}
+    rejections: dict[str, bool] = {name: False for name in family}
+
+    stop = False
+    for i, outcome in enumerate(sorted_outcomes):
+        threshold = alpha / (m - i)
+        thresholds[outcome.name] = float(threshold)
+
+        if stop:
+            rejections[outcome.name] = False
+            continue
+
+        if float(outcome.p_value) <= threshold:
+            rejections[outcome.name] = True
+        else:
+            rejections[outcome.name] = False
+            stop = True
+
+    return {
+        "method": "holm-bonferroni",
+        "family": family,
+        "raw_p_values": raw_p_values,
+        "sorted_tests": [outcome.name for outcome in sorted_outcomes],
+        "thresholds": thresholds,
+        "rejections": rejections,
+        "any_reject": any(rejections.values()),
+    }

--- a/src/variance_test/models.py
+++ b/src/variance_test/models.py
@@ -6,6 +6,41 @@ from dataclasses import dataclass
 
 
 @dataclass
+class RobustVRConfig:
+    """Configuration contract for optional robust variance-ratio diagnostics."""
+
+    enabled: bool = False
+    enable_avr: bool = True
+    enable_wbavr: bool = True
+    enable_chow_denning: bool = True
+    bootstrap_reps: int = 999
+    bootstrap_seed: int | None = None
+    wild_weights: str = "rademacher"
+    chow_denning_calibration: str = "sidak_normal"
+    q_list: tuple[int, ...] | None = None
+    max_automatic_q: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.bootstrap_reps < 199:
+            raise ValueError("bootstrap_reps must be at least 199.")
+        if self.wild_weights != "rademacher":
+            raise ValueError("wild_weights currently supports only 'rademacher'.")
+        if self.chow_denning_calibration != "sidak_normal":
+            raise ValueError(
+                "chow_denning_calibration currently supports only 'sidak_normal'."
+            )
+        if self.q_list is not None:
+            if not self.q_list:
+                raise ValueError("q_list cannot be empty when provided.")
+            if any((not isinstance(q, int)) or q <= 0 for q in self.q_list):
+                raise ValueError("All q_list values must be positive integers.")
+            if any(curr <= prev for prev, curr in zip(self.q_list, self.q_list[1:])):
+                raise ValueError("q_list must be strictly increasing.")
+        if self.max_automatic_q is not None and self.max_automatic_q < 2:
+            raise ValueError("max_automatic_q must be at least 2 when provided.")
+
+
+@dataclass
 class BatteryConfig:
     """Configuration contract for the weak-form battery orchestration layer."""
 
@@ -18,6 +53,7 @@ class BatteryConfig:
     rolling_window: int | None = None
     rolling_step: int = 1
     seed: int | None = None
+    robust_vr: RobustVRConfig | None = None
 
     def __post_init__(self) -> None:
         if self.input_kind not in {"log_prices", "returns"}:
@@ -42,6 +78,8 @@ class BatteryConfig:
             raise ValueError("rolling_window must be None or at least 2.")
         if self.rolling_step < 1:
             raise ValueError("rolling_step must be at least 1.")
+        if self.robust_vr is not None and not isinstance(self.robust_vr, RobustVRConfig):
+            raise ValueError("robust_vr must be None or a RobustVRConfig instance.")
 
 
 @dataclass

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -8,6 +8,7 @@ from variance_test import (
     EMH,
     NormalizedSeries,
     PricePaths,
+    RobustVRConfig,
     SimulationConfig,
     SimulationResults,
     TestOutcome,
@@ -32,6 +33,7 @@ EXPECTED_PUBLIC_API = {
     "NormalizedSeries",
     "normalize_series",
     "BatteryConfig",
+    "RobustVRConfig",
     "TestOutcome",
     "BatteryOutcome",
     "run_weak_form_battery",
@@ -59,18 +61,19 @@ def test_simulation_entities_importable_from_root() -> None:
 
 
 def test_new_data_contract_api_importable_from_root() -> None:
-    """Sprint 2 data/model contracts must be importable from package root."""
+    """Data/model contracts must be importable from package root."""
     assert NormalizedSeries is not None
     assert normalize_series is not None
     assert BatteryConfig is not None
+    assert RobustVRConfig is not None
     assert TestOutcome is not None
     assert BatteryOutcome is not None
-
 
 
 def test_run_weak_form_battery_importable_from_root() -> None:
     """run_weak_form_battery must be importable from package root."""
     assert run_weak_form_battery is not None
+
 
 def test_all_contains_exact_public_api() -> None:
     """__all__ must match the required minimal API exactly."""

--- a/tests/test_robust_vr.py
+++ b/tests/test_robust_vr.py
@@ -1,0 +1,339 @@
+"""Tests for robust variance-ratio diagnostics introduced in v0.2.0."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from variance_test import BatteryConfig, EMH, RobustVRConfig, run_weak_form_battery
+from variance_test.diagnostics.robust_vr import _compute_heteroskedastic_z2_from_log_prices
+
+
+def _iid_returns() -> np.ndarray:
+    rng = np.random.default_rng(42)
+    return rng.normal(0.0, 0.01, size=5000)
+
+
+def _ar1_returns() -> np.ndarray:
+    rng = np.random.default_rng(42)
+    size = 5000
+    eps = rng.normal(0.0, 0.01, size=size)
+    values = np.zeros(size, dtype=float)
+    phi = 0.3
+    for idx in range(1, size):
+        values[idx] = phi * values[idx - 1] + eps[idx]
+    return values
+
+
+def _as_log_prices(returns: np.ndarray) -> np.ndarray:
+    return np.concatenate(([0.0], np.cumsum(returns)))
+
+
+def _base_config(input_kind: str, alpha: float = 0.05, robust: RobustVRConfig | None = None) -> BatteryConfig:
+    return BatteryConfig(
+        input_kind=input_kind,
+        alpha=alpha,
+        q_list=(2, 4, 8, 16),
+        ljung_box_lags=(5, 10, 20),
+        runs_test=True,
+        arch_lm_lags=5,
+        robust_vr=robust,
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"bootstrap_reps": 198},
+        {"wild_weights": "normal"},
+        {"chow_denning_calibration": "smm"},
+        {"q_list": (2, 2, 4)},
+        {"max_automatic_q": 1},
+    ],
+)
+def test_robust_config_validation_invalid(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        RobustVRConfig(**kwargs)
+
+
+def test_robust_config_validation_valid() -> None:
+    assert BatteryConfig(robust_vr=None)
+    assert BatteryConfig(robust_vr=RobustVRConfig())
+
+
+def test_pure_math_helper_matches_emh_vrt_heteroskedastic_z2() -> None:
+    rng = np.random.default_rng(7)
+    returns = rng.normal(0.0, 0.01, size=200)
+    log_prices = _as_log_prices(returns)
+
+    emh = EMH()
+    for q in (2, 4, 8, 16):
+        helper = _compute_heteroskedastic_z2_from_log_prices(log_prices, q=q)
+        expected, _ = emh.vrt(
+            X=log_prices,
+            q=q,
+            heteroskedastic=True,
+            centered=True,
+            unbiased=True,
+            annualize=False,
+            input_kind="log_prices",
+            alternative="two-sided",
+        )
+        assert np.isclose(helper, expected, atol=1e-10, rtol=1e-8)
+
+
+def test_robust_disabled_preserves_v1_keys_and_multiple_testing() -> None:
+    returns = _iid_returns()
+    outcome = run_weak_form_battery(returns, config=_base_config(input_kind="returns"))
+
+    assert "avr" not in outcome.tests
+    assert "wbavr" not in outcome.tests
+    assert "chow_denning" not in outcome.tests
+    assert tuple(outcome.multiple_testing.keys()) == ("variance_ratio_holm", "battery_summary")
+
+
+def test_enabling_robust_keeps_v1_statistics_identical() -> None:
+    returns = _iid_returns()
+    base = run_weak_form_battery(returns, config=_base_config(input_kind="returns"))
+    robust = run_weak_form_battery(
+        returns,
+        config=_base_config(
+            input_kind="returns",
+            robust=RobustVRConfig(enabled=True, bootstrap_reps=199, bootstrap_seed=42),
+        ),
+    )
+
+    comparable = [
+        *(f"variance_ratio_q{q}" for q in (2, 4, 8, 16)),
+        "variance_ratio_holm",
+        "ljung_box_returns",
+        "ljung_box_squared_returns",
+        "runs_test_signs",
+        "arch_lm",
+    ]
+    for name in comparable:
+        assert base.tests[name].statistic == robust.tests[name].statistic
+        assert base.tests[name].p_value == robust.tests[name].p_value
+        assert base.tests[name].reject_null == robust.tests[name].reject_null
+
+
+def test_robust_enabled_output_shape_and_order() -> None:
+    returns = _iid_returns()
+    outcome = run_weak_form_battery(
+        returns,
+        config=_base_config(
+            input_kind="returns",
+            robust=RobustVRConfig(enabled=True, bootstrap_reps=199, bootstrap_seed=42),
+        ),
+    )
+
+    assert list(outcome.tests.keys()) == [
+        "variance_ratio_q2",
+        "variance_ratio_q4",
+        "variance_ratio_q8",
+        "variance_ratio_q16",
+        "variance_ratio_holm",
+        "ljung_box_returns",
+        "ljung_box_squared_returns",
+        "runs_test_signs",
+        "arch_lm",
+        "avr",
+        "wbavr",
+        "chow_denning",
+    ]
+    assert tuple(outcome.multiple_testing.keys()) == (
+        "variance_ratio_holm",
+        "battery_summary",
+        "robust_vr_summary",
+    )
+    assert tuple(outcome.multiple_testing["robust_vr_summary"].keys()) == (
+        "tests_included",
+        "rejected_tests",
+        "n_rejections",
+        "any_reject",
+    )
+
+
+def test_robust_selective_enable_rules() -> None:
+    returns = _iid_returns()
+    for robust in (
+        RobustVRConfig(enabled=True, enable_wbavr=False, enable_chow_denning=False, bootstrap_reps=199),
+        RobustVRConfig(enabled=True, enable_avr=False, enable_chow_denning=False, bootstrap_reps=199),
+        RobustVRConfig(enabled=True, enable_avr=False, enable_wbavr=False, bootstrap_reps=199),
+    ):
+        outcome = run_weak_form_battery(returns, config=_base_config(input_kind="returns", robust=robust))
+        included = outcome.multiple_testing["robust_vr_summary"]["tests_included"]
+        assert len(included) == 1
+        assert included[0] in {"avr", "wbavr", "chow_denning"}
+
+
+def test_returns_vs_log_prices_equivalence_for_robust_tests() -> None:
+    returns = _iid_returns()
+    log_prices = _as_log_prices(returns)
+    robust = RobustVRConfig(enabled=True, bootstrap_reps=199, bootstrap_seed=42)
+
+    out_ret = run_weak_form_battery(returns, config=_base_config("returns", robust=robust))
+    out_log = run_weak_form_battery(log_prices, config=_base_config("log_prices", robust=robust))
+
+    for name in ("avr", "wbavr", "chow_denning"):
+        assert np.isclose(out_ret.tests[name].statistic, out_log.tests[name].statistic, atol=1e-10, rtol=1e-8)
+        assert np.isclose(out_ret.tests[name].p_value, out_log.tests[name].p_value, atol=1e-10, rtol=1e-8)
+        assert out_ret.tests[name].reject_null == out_log.tests[name].reject_null
+
+
+def test_avr_contract_and_behavior() -> None:
+    iid = _iid_returns()
+    config_iid = _base_config(
+        "returns",
+        alpha=0.01,
+        robust=RobustVRConfig(enabled=True, enable_wbavr=False, enable_chow_denning=False, bootstrap_reps=199),
+    )
+    out_iid = run_weak_form_battery(iid, config=config_iid)
+    avr = out_iid.tests["avr"]
+
+    assert np.isfinite(avr.statistic)
+    assert np.isfinite(avr.p_value)
+    for key in ("selected_q", "q_raw", "rho_hat", "alpha_hat", "vr_value", "input_kind_used"):
+        assert key in avr.metadata
+    assert avr.metadata["selected_q"] >= 2
+    assert avr.reject_null is False
+
+    out_iid_2 = run_weak_form_battery(iid, config=config_iid)
+    assert avr.statistic == out_iid_2.tests["avr"].statistic
+    assert avr.p_value == out_iid_2.tests["avr"].p_value
+
+    ar1 = _ar1_returns()
+    config_ar1 = _base_config(
+        "returns",
+        alpha=0.05,
+        robust=RobustVRConfig(enabled=True, enable_wbavr=False, enable_chow_denning=False, bootstrap_reps=199),
+    )
+    out_ar1 = run_weak_form_battery(ar1, config=config_ar1)
+    assert out_ar1.tests["avr"].reject_null is True
+
+
+def test_wbavr_contract_and_behavior() -> None:
+    iid = _iid_returns()
+    config_iid = _base_config(
+        "returns",
+        alpha=0.01,
+        robust=RobustVRConfig(enabled=True, enable_avr=False, enable_chow_denning=False, bootstrap_reps=199, bootstrap_seed=42),
+    )
+    out_iid = run_weak_form_battery(iid, config=config_iid)
+    wbavr = out_iid.tests["wbavr"]
+
+    assert np.isfinite(wbavr.statistic)
+    assert np.isfinite(wbavr.p_value)
+    for key in (
+        "selected_q",
+        "bootstrap_reps",
+        "bootstrap_seed",
+        "wild_weights",
+        "bootstrap_quantiles",
+        "n_bootstrap_effective",
+    ):
+        assert key in wbavr.metadata
+    assert set(wbavr.metadata["bootstrap_quantiles"].keys()) == {"q90", "q95", "q99"}
+    assert wbavr.reject_null is False
+
+    out_iid_2 = run_weak_form_battery(iid, config=config_iid)
+    assert wbavr.statistic == out_iid_2.tests["wbavr"].statistic
+    assert wbavr.p_value == out_iid_2.tests["wbavr"].p_value
+
+    ar1 = _ar1_returns()
+    config_ar1 = _base_config(
+        "returns",
+        alpha=0.05,
+        robust=RobustVRConfig(enabled=True, enable_avr=False, enable_chow_denning=False, bootstrap_reps=199, bootstrap_seed=42),
+    )
+    out_ar1 = run_weak_form_battery(ar1, config=config_ar1)
+    assert out_ar1.tests["wbavr"].reject_null is True
+
+
+def test_chow_denning_contract_and_behavior() -> None:
+    iid = _iid_returns()
+    config_iid = _base_config(
+        "returns",
+        alpha=0.01,
+        robust=RobustVRConfig(enabled=True, enable_avr=False, enable_wbavr=False, bootstrap_reps=199),
+    )
+    out_iid = run_weak_form_battery(iid, config=config_iid)
+    cd = out_iid.tests["chow_denning"]
+
+    per_q = cd.metadata["per_q_statistics"]
+    assert np.isclose(cd.statistic, max(abs(v) for v in per_q.values()))
+    assert cd.metadata["familywise_p_value"] == cd.p_value
+    assert cd.metadata["calibration"] == "sidak_normal"
+
+    for q, z_val in per_q.items():
+        expected = 2 * (1 - norm.cdf(abs(z_val)))
+        assert np.isclose(cd.metadata["per_q_p_values"][q], expected, atol=1e-10, rtol=1e-8)
+
+    assert cd.reject_null is False
+
+    ar1 = _ar1_returns()
+    config_ar1 = _base_config(
+        "returns",
+        alpha=0.05,
+        robust=RobustVRConfig(enabled=True, enable_avr=False, enable_wbavr=False, bootstrap_reps=199),
+    )
+    out_ar1 = run_weak_form_battery(ar1, config=config_ar1)
+    assert out_ar1.tests["chow_denning"].reject_null is True
+
+
+def test_short_series_non_computable_robust_without_crash() -> None:
+    short_returns = np.array([0.01, -0.01], dtype=float)
+    config = BatteryConfig(
+        input_kind="returns",
+        q_list=(1,),
+        ljung_box_lags=(1,),
+        arch_lm_lags=1,
+        runs_test=False,
+        robust_vr=RobustVRConfig(enabled=True, bootstrap_reps=199),
+    )
+    outcome = run_weak_form_battery(short_returns, config=config)
+
+    for name in ("avr", "wbavr", "chow_denning"):
+        robust_test = outcome.tests[name]
+        assert robust_test.statistic is None
+        assert robust_test.p_value is None
+        assert robust_test.reject_null is None
+        assert robust_test.warnings
+
+
+def test_computable_robust_tests_p_value_and_reject_consistency() -> None:
+    returns = _iid_returns()
+    config = _base_config(
+        "returns",
+        alpha=0.05,
+        robust=RobustVRConfig(enabled=True, bootstrap_reps=199, bootstrap_seed=42),
+    )
+    outcome = run_weak_form_battery(returns, config=config)
+
+    for name in ("avr", "wbavr", "chow_denning"):
+        test = outcome.tests[name]
+        assert test.p_value is not None
+        assert 0.0 <= test.p_value <= 1.0
+        assert test.reject_null == (test.p_value < config.alpha)
+
+
+def test_robust_enable_does_not_change_rolling_payload_shape() -> None:
+    returns = _iid_returns()
+    config = _base_config(
+        "returns",
+        robust=RobustVRConfig(enabled=True, bootstrap_reps=199, bootstrap_seed=42),
+    )
+    config.rolling_window = 120
+    config.rolling_step = 10
+
+    outcome = run_weak_form_battery(returns, config=config)
+    assert outcome.rolling is not None
+    assert set(outcome.rolling["tests"].keys()) == {
+        "variance_ratio_q2",
+        "variance_ratio_q4",
+        "variance_ratio_q8",
+        "variance_ratio_q16",
+        "ljung_box_returns",
+        "ljung_box_squared_returns",
+    }


### PR DESCRIPTION
### Motivation
- Add an opt-in robust variance-ratio family (AVR, WBAVR, Chow-Denning-style max test) while preserving the existing v1 weak-form battery behavior and public API.
- Introduce minimal internal refactor to separate diagnostic helpers from orchestration for easier extensibility and to support efficient bootstrap math on pre-normalized arrays.
- Provide deterministic, well-tested implementations and documentation for v0.2.0 without adding heavy dependencies or rolling support for the new robust tests.

### Description
- Added `RobustVRConfig` and extended `BatteryConfig` with `robust_vr`, implementing validation rules in `__post_init__` and exporting `RobustVRConfig` from the package root (`src/variance_test/models.py`, `src/variance_test/__init__.py`).
- Refactored internal helpers into a new `src/variance_test/diagnostics/` subpackage and moved classic helpers (`vr_classic.py`, `ljung_box.py`, `runs.py`, `arch_lm.py`) out of `battery.py` while keeping `battery.py` as the orchestrator.
- Implemented robust VR internals and pure math helpers in `diagnostics/robust_vr.py`, including `_compute_vr_value_from_log_prices`, `_compute_heteroskedastic_z2_from_log_prices`, automatic `q` selection (`AVR`), wild-bootstrap `WBAVR` using Rademacher weights, and a Chow-Denning-style max test with Sidak-normal calibration (`chow_denning`).
- Integrated robust tests into `run_weak_form_battery` as opt-in, appending `avr`, `wbavr`, and `chow_denning` in the required order and adding `multiple_testing["robust_vr_summary"]` only when robust VR is enabled; v1 outputs and rolling payload are unchanged when not enabled (`src/variance_test/battery.py`).

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully: `99 passed` with a small number of non-critical warnings relating to numerical edge cases.
- Added comprehensive unit tests for the robust features in `tests/test_robust_vr.py` covering config validation, pure-math parity with `EMH().vrt`, deterministic bootstrap behavior, returns/log_prices equivalence, edge cases, and synthetic IID/AR(1) behavior.
- Verified public API expectations in the updated `tests/test_public_api.py` and ensured `RobustVRConfig` is exported and present in `__all__`.
- Attempted `python -m build` in this environment but packaging build could not be executed because the `build` module is not available and network-restricted installation of that tool failed; this did not affect test success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8430e99a88323b77e42b4477e0f8e)